### PR TITLE
hotfix/15786 quests flow hotfix

### DIFF
--- a/components/CtmModal/CtmModalInvitation/index.vue
+++ b/components/CtmModal/CtmModalInvitation/index.vue
@@ -154,7 +154,7 @@ export default {
         title: this.$t('modals.inviteSend'),
         subtitle: this.$t('modals.invitationSendText'),
         type: 'goToChat',
-        button: 'Go to chat',
+        button: this.$t('btn.goToChat'),
       });
     },
   },

--- a/components/CtmModal/CtmModalInvitation/index.vue
+++ b/components/CtmModal/CtmModalInvitation/index.vue
@@ -137,7 +137,7 @@ export default {
       }
     },
     cardsLevels() {
-      const { card, disabled } = this;
+      const { card } = this;
       return [
         { card__level_reliable: card.level.code === '2' },
         { card__level_checked: card.level.code === '3' },
@@ -153,6 +153,8 @@ export default {
         img: require('~/assets/img/ui/inviteSend.svg'),
         title: this.$t('modals.inviteSend'),
         subtitle: this.$t('modals.invitationSendText'),
+        type: 'goToChat',
+        button: 'Go to chat',
       });
     },
   },

--- a/components/CtmModal/CtmModalReviewEmployer/index.vue
+++ b/components/CtmModal/CtmModalReviewEmployer/index.vue
@@ -70,7 +70,13 @@ export default {
       options: 'modals/getOptions',
     }),
   },
+  mounted() {
+    this.getQuestRating();
+  },
   methods: {
+    getQuestRating() {
+      this.localRating = localStorage.getItem('questRating');
+    },
     hide() {
       this.CloseModal();
     },

--- a/components/CtmModal/CtmModalReviewEmployer/index.vue
+++ b/components/CtmModal/CtmModalReviewEmployer/index.vue
@@ -29,7 +29,7 @@
             <div class="buttons__wrapper">
               <base-btn
                 class="buttons__action"
-                @click="showThanksModal"
+                @click="sendReviewForUser()"
               >
                 {{ $t('meta.send') }}
               </base-btn>
@@ -77,8 +77,25 @@ export default {
     getQuestRating() {
       this.localRating = localStorage.getItem('questRating');
     },
+    removeLocalStorageRating() {
+      localStorage.removeItem('questRating');
+    },
     hide() {
       this.CloseModal();
+    },
+    sendReviewForUser() {
+      const payload = {
+        questId: this.options.item.id,
+        message: this.textArea,
+        mark: this.localRating,
+      };
+      try {
+        this.$store.dispatch('user/sendReviewForUser', payload);
+        this.showThanksModal();
+        this.removeLocalStorageRating();
+      } catch (e) {
+        console.log(e);
+      }
     },
     showThanksModal() {
       this.ShowModal({

--- a/components/CtmModal/CtmModalSendARequest/index.vue
+++ b/components/CtmModal/CtmModalSendARequest/index.vue
@@ -60,7 +60,7 @@
 import { mapGetters } from 'vuex';
 import Dropzone from 'nuxt-dropzone';
 import modals from '~/store/modals/modals';
-import { InfoModeW, QStatuses } from '~/utils/enums';
+import { InfoModeWorker, QuestStatuses } from '~/utils/enums';
 
 export default {
   name: 'ModalSendARequest',
@@ -100,9 +100,9 @@ export default {
         message: this.text,
       };
       try {
-        if (QStatuses.Rejected) {
+        if (QuestStatuses.Rejected) {
           await this.$store.dispatch('quests/respondOnQuest', { data, questId });
-          await this.$store.dispatch('quests/setInfoDataMode', InfoModeW.Rejected);
+          await this.$store.dispatch('quests/setInfoDataMode', InfoModeWorker.Rejected);
         }
       } catch (e) {
         console.log(e);

--- a/components/CtmModal/CtmModalSendARequest/index.vue
+++ b/components/CtmModal/CtmModalSendARequest/index.vue
@@ -60,6 +60,7 @@
 import { mapGetters } from 'vuex';
 import Dropzone from 'nuxt-dropzone';
 import modals from '~/store/modals/modals';
+import { InfoModeW, QStatuses } from '~/utils/enums';
 
 export default {
   name: 'ModalSendARequest',
@@ -99,8 +100,10 @@ export default {
         message: this.text,
       };
       try {
-        await this.$store.dispatch('quests/respondOnQuest', { data, questId });
-        await this.$store.dispatch('quests/setInfoDataMode', 3);
+        if (QStatuses.Rejected) {
+          await this.$store.dispatch('quests/respondOnQuest', { data, questId });
+          await this.$store.dispatch('quests/setInfoDataMode', InfoModeW.Rejected);
+        }
       } catch (e) {
         console.log(e);
       }

--- a/components/CtmModal/CtmModalStatus/index.vue
+++ b/components/CtmModal/CtmModalStatus/index.vue
@@ -49,24 +49,34 @@
           {{ $t('meta.ok') }}
         </span>
       </base-btn>
-      <base-btn
+      <div
         v-if="options.type === 'goToChat'"
-        class="status__action"
-        @click="goToChat()"
+        class="btn__cols-two"
       >
-        <span
-          v-if="options.button"
-          class="status__text"
+        <base-btn
+          class="status__action"
+          mode="agree"
+          @click="goToChat()"
         >
-          {{ options.button }}
-        </span>
-        <span
-          v-else
-          class="status__text"
+          <span
+            v-if="options.button"
+            class="status__text"
+          >
+            {{ options.button }}
+          </span>
+        </base-btn>
+        <base-btn
+          class="status__action"
+          @click="goToChat()"
         >
-          {{ $t('meta.ok') }}
-        </span>
-      </base-btn>
+          <span
+            class="status__text"
+            @click="hide()"
+          >
+            {{ $t('meta.ok') }}
+          </span>
+        </base-btn>
+      </div>
       <base-btn
         v-else
         class="status__action"
@@ -149,6 +159,14 @@ export default {
 
 <style lang="scss" scoped>
 
+.btn {
+  &__cols-two {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 10px;
+  }
+}
+
 .status {
   max-width: 337px !important;
   height: auto !important;
@@ -170,7 +188,7 @@ export default {
   &__action {
     margin-top: 10px;
   }
-  &__desc{
+  &__desc {
     font-size: 16px;
     line-height: 130%;
     text-align: center;

--- a/components/CtmModal/CtmModalStatus/index.vue
+++ b/components/CtmModal/CtmModalStatus/index.vue
@@ -50,6 +50,24 @@
         </span>
       </base-btn>
       <base-btn
+        v-if="options.type === 'goToChat'"
+        class="status__action"
+        @click="goToChat()"
+      >
+        <span
+          v-if="options.button"
+          class="status__text"
+        >
+          {{ options.button }}
+        </span>
+        <span
+          v-else
+          class="status__text"
+        >
+          {{ $t('meta.ok') }}
+        </span>
+      </base-btn>
+      <base-btn
         v-else
         class="status__action"
         @click="hide()"
@@ -84,6 +102,7 @@ export default {
   computed: {
     ...mapGetters({
       options: 'modals/getOptions',
+      chatInfoInviteOnQuest: 'quests/getChatInfoInviteOnQuest',
     }),
   },
   async mounted() {
@@ -97,6 +116,11 @@ export default {
     }
   },
   methods: {
+    goToChat() {
+      const chatId = this.chatInfoInviteOnQuest.id;
+      this.$router.push(`/messages/${chatId}`);
+      this.hide();
+    },
     installMetamask() {
       window.open('https://metamask.io/download.html');
     },

--- a/components/CtmModal/CtmModalStatus/index.vue
+++ b/components/CtmModal/CtmModalStatus/index.vue
@@ -65,17 +65,6 @@
             {{ options.button }}
           </span>
         </base-btn>
-        <base-btn
-          class="status__action"
-          @click="goToChat()"
-        >
-          <span
-            class="status__text"
-            @click="hide()"
-          >
-            {{ $t('meta.ok') }}
-          </span>
-        </base-btn>
       </div>
       <base-btn
         v-else

--- a/components/app/info/index.vue
+++ b/components/app/info/index.vue
@@ -4,14 +4,15 @@
     :class="infoClass"
   >
     <div
-      v-if="userRole === 'employer' && ![1,3,5].includes(infoDataMode)"
+      v-if="userRole === 'employer'
+        && ![InfoModeEmployer.RaiseViews, InfoModeEmployer.Created].includes(infoDataMode)"
       class="info__body"
     >
       <div class="info__left">
         <div
           class="info__text"
           :class="[
-            {'info__text_white': ![3,6].includes(infoDataMode)}
+            {'info__text_white': ![InfoModeEmployer.Created, InfoModeEmployer.WaitConfirm].includes(infoDataMode)}
           ]"
         >
           {{ infoStatusText }}
@@ -27,10 +28,10 @@
           class="info__text"
           :class="[
             {
-              'info__text_white': ![3,8].includes(infoDataMode)
+              'info__text_white': ![InfoModeWorker.Rejected, InfoModeWorker.Closed].includes(infoDataMode)
             },
             {
-              'info__text_black': [3,8].includes(infoDataMode)
+              'info__text_black': [InfoModeWorker.Rejected, InfoModeWorker.Closed].includes(infoDataMode)
             }
           ]"
         >
@@ -39,7 +40,7 @@
       </div>
       <div class="info__right">
         <div
-          v-if="[3].includes(infoDataMode)"
+          v-if="infoDataMode === InfoModeWorker.Rejected"
         >
           <base-btn mode="showYourMessage">
             <template v-slot:right>
@@ -56,6 +57,7 @@
 <script>
 
 import { mapGetters } from 'vuex';
+import { InfoModeE, InfoModeW } from '~/utils/enums';
 
 export default {
   name: 'InfoVue',
@@ -66,27 +68,33 @@ export default {
     },
   },
   computed: {
+    InfoModeEmployer() {
+      return InfoModeE;
+    },
+    InfoModeWorker() {
+      return InfoModeW;
+    },
     infoStatusText() {
       if (this.userRole === 'employer') {
         const obj = {
-          2: 'quests.activeQuest',
-          4: 'quests.waitWorker',
-          6: 'quests.pendingConsideration',
-          7: 'quests.dispute',
-          8: 'performed.title',
-          9: 'performed.title',
+          [InfoModeE.Active]: 'quests.activeQuest',
+          [InfoModeE.WaitWorker]: 'quests.waitWorker',
+          [InfoModeE.WaitConfirm]: 'quests.pendingConsideration',
+          [InfoModeE.Dispute]: 'quests.dispute',
+          [InfoModeE.Closed]: 'quests.closed',
+          [InfoModeE.Done]: 'performed.title',
         };
         return this.$t(`${obj[this.infoDataMode]}`);
       }
       if (this.userRole === 'worker') {
         const obj = {
-          1: 'invite.title',
-          2: 'quests.activeQuest',
-          3: 'response.title',
-          4: 'quests.completed',
-          7: 'quests.dispute',
-          8: 'quests.questClosed',
-          9: 'quests.completed',
+          [InfoModeW.ADChat]: 'invite.title',
+          [InfoModeW.Active]: 'quests.activeQuest',
+          [InfoModeW.Rejected]: 'quests.requested',
+          [InfoModeW.WaitConfirm]: 'quests.pendingConsideration',
+          [InfoModeW.Dispute]: 'quests.dispute',
+          [InfoModeW.Closed]: 'quests.questClosed',
+          [InfoModeW.Done]: 'quests.completed',
         };
         return this.$t(`${obj[this.infoDataMode]}`);
       }
@@ -96,38 +104,44 @@ export default {
       if (this.userRole === 'worker') {
         return [
           {
-            'info_bg-yellow': [1].includes(this.infoDataMode),
+            'info-hide': this.infoDataMode === InfoModeW.Created,
           },
           {
-            'info_bg-green': [2].includes(this.infoDataMode),
+            'info_bg-yellow': this.infoDataMode === InfoModeW.ADChat,
           },
           {
-            'info_bg-grey': [3].includes(this.infoDataMode),
+            'info_bg-green': this.infoDataMode === InfoModeW.Active,
           },
           {
-            'info_bg-blue': [4, 9].includes(this.infoDataMode),
+            'info_bg-grey': this.infoDataMode === InfoModeW.Rejected,
           },
           {
-            'info_bg-red': [7, 8].includes(this.infoDataMode),
+            'info_bg-blue': [InfoModeW.WaitConfirm, InfoModeW.Done].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-red': [InfoModeW.Dispute, InfoModeW.Closed].includes(this.infoDataMode),
           },
         ];
       }
       if (this.userRole === 'employer') {
         return [
           {
-            'info_bg-yellow': [4].includes(this.infoDataMode),
+            'info-hide': this.infoDataMode === InfoModeE.Created,
           },
           {
-            'info_bg-green': [2].includes(this.infoDataMode),
+            'info_bg-yellow': this.infoDataMode === InfoModeE.WaitWorker,
           },
           {
-            'info_bg-grey': [6].includes(this.infoDataMode),
+            'info_bg-green': this.infoDataMode === InfoModeE.Active,
           },
           {
-            'info_bg-red': [7].includes(this.infoDataMode),
+            'info_bg-grey': this.infoDataMode === InfoModeE.WaitConfirm,
           },
           {
-            'info_bg-blue': [8, 9].includes(this.infoDataMode),
+            'info_bg-red': this.infoDataMode === InfoModeE.Dispute,
+          },
+          {
+            'info_bg-blue': [InfoModeE.Closed, InfoModeE.Done].includes(this.infoDataMode),
           },
         ];
       }
@@ -159,6 +173,9 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
+  &-hide {
+    display: none;
+  }
   &_bg-green {
     background-color: $green;
   }

--- a/components/app/info/index.vue
+++ b/components/app/info/index.vue
@@ -11,7 +11,7 @@
         <div
           class="info__text"
           :class="[
-            {'info__text_white': ![3,6,7].includes(infoDataMode)}
+            {'info__text_white': ![3,6].includes(infoDataMode)}
           ]"
         >
           {{ infoStatusText }}

--- a/components/app/info/index.vue
+++ b/components/app/info/index.vue
@@ -93,20 +93,45 @@ export default {
       return '';
     },
     infoClass() {
-      return [
-        {
-          'info_bg-yellow': [1].includes(this.infoDataMode),
-        },
-        {
-          'info_bg-green': [2].includes(this.infoDataMode),
-        },
-        {
-          'info_bg-grey': [3].includes(this.infoDataMode),
-        },
-        {
-          'info_bg-blue': [4, 9].includes(this.infoDataMode),
-        },
-      ];
+      if (this.userRole === 'worker') {
+        return [
+          {
+            'info_bg-yellow': [1].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-green': [2].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-grey': [3].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-blue': [4, 9].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-red': [7, 8].includes(this.infoDataMode),
+          },
+        ];
+      }
+      if (this.userRole === 'employer') {
+        return [
+          {
+            'info_bg-yellow': [4].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-green': [2].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-grey': [6].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-red': [7].includes(this.infoDataMode),
+          },
+          {
+            'info_bg-blue': [8, 9].includes(this.infoDataMode),
+          },
+        ];
+      }
+      return '';
     },
     ...mapGetters({
       tags: 'ui/getTags',
@@ -145,6 +170,9 @@ export default {
   }
   &_bg-blue {
     background-color: $blue;
+  }
+  &_bg-red {
+    background-color: $red;
   }
   &__body {
     max-width: 1180px;

--- a/components/app/info/index.vue
+++ b/components/app/info/index.vue
@@ -27,10 +27,10 @@
           class="info__text"
           :class="[
             {
-              'info__text_white': ![3,7,8].includes(infoDataMode)
+              'info__text_white': ![3,8].includes(infoDataMode)
             },
             {
-              'info__text_black': [3,7,8].includes(infoDataMode)
+              'info__text_black': [3,8].includes(infoDataMode)
             }
           ]"
         >

--- a/components/app/info/index.vue
+++ b/components/app/info/index.vue
@@ -57,7 +57,7 @@
 <script>
 
 import { mapGetters } from 'vuex';
-import { InfoModeE, InfoModeW } from '~/utils/enums';
+import { InfoModeEmployer, InfoModeWorker } from '~/utils/enums';
 
 export default {
   name: 'InfoVue',
@@ -69,32 +69,32 @@ export default {
   },
   computed: {
     InfoModeEmployer() {
-      return InfoModeE;
+      return InfoModeEmployer;
     },
     InfoModeWorker() {
-      return InfoModeW;
+      return InfoModeWorker;
     },
     infoStatusText() {
       if (this.userRole === 'employer') {
         const obj = {
-          [InfoModeE.Active]: 'quests.activeQuest',
-          [InfoModeE.WaitWorker]: 'quests.waitWorker',
-          [InfoModeE.WaitConfirm]: 'quests.pendingConsideration',
-          [InfoModeE.Dispute]: 'quests.dispute',
-          [InfoModeE.Closed]: 'quests.closed',
-          [InfoModeE.Done]: 'performed.title',
+          [InfoModeEmployer.Active]: 'quests.activeQuest',
+          [InfoModeEmployer.WaitWorker]: 'quests.waitWorker',
+          [InfoModeEmployer.WaitConfirm]: 'quests.pendingConsideration',
+          [InfoModeEmployer.Dispute]: 'quests.dispute',
+          [InfoModeEmployer.Closed]: 'quests.closed',
+          [InfoModeEmployer.Done]: 'performed.title',
         };
         return this.$t(`${obj[this.infoDataMode]}`);
       }
       if (this.userRole === 'worker') {
         const obj = {
-          [InfoModeW.ADChat]: 'invite.title',
-          [InfoModeW.Active]: 'quests.activeQuest',
-          [InfoModeW.Rejected]: 'quests.requested',
-          [InfoModeW.WaitConfirm]: 'quests.pendingConsideration',
-          [InfoModeW.Dispute]: 'quests.dispute',
-          [InfoModeW.Closed]: 'quests.questClosed',
-          [InfoModeW.Done]: 'quests.completed',
+          [InfoModeWorker.ADChat]: 'invite.title',
+          [InfoModeWorker.Active]: 'quests.activeQuest',
+          [InfoModeWorker.Rejected]: 'quests.requested',
+          [InfoModeWorker.WaitConfirm]: 'quests.pendingConsideration',
+          [InfoModeWorker.Dispute]: 'quests.dispute',
+          [InfoModeWorker.Closed]: 'quests.questClosed',
+          [InfoModeWorker.Done]: 'quests.completed',
         };
         return this.$t(`${obj[this.infoDataMode]}`);
       }
@@ -104,44 +104,44 @@ export default {
       if (this.userRole === 'worker') {
         return [
           {
-            'info-hide': this.infoDataMode === InfoModeW.Created,
+            'info-hide': this.infoDataMode === InfoModeWorker.Created,
           },
           {
-            'info_bg-yellow': this.infoDataMode === InfoModeW.ADChat,
+            'info_bg-yellow': this.infoDataMode === InfoModeWorker.ADChat,
           },
           {
-            'info_bg-green': this.infoDataMode === InfoModeW.Active,
+            'info_bg-green': this.infoDataMode === InfoModeWorker.Active,
           },
           {
-            'info_bg-grey': this.infoDataMode === InfoModeW.Rejected,
+            'info_bg-grey': this.infoDataMode === InfoModeWorker.Rejected,
           },
           {
-            'info_bg-blue': [InfoModeW.WaitConfirm, InfoModeW.Done].includes(this.infoDataMode),
+            'info_bg-blue': [InfoModeWorker.WaitConfirm, InfoModeWorker.Done].includes(this.infoDataMode),
           },
           {
-            'info_bg-red': [InfoModeW.Dispute, InfoModeW.Closed].includes(this.infoDataMode),
+            'info_bg-red': [InfoModeWorker.Dispute, InfoModeWorker.Closed].includes(this.infoDataMode),
           },
         ];
       }
       if (this.userRole === 'employer') {
         return [
           {
-            'info-hide': this.infoDataMode === InfoModeE.Created,
+            'info-hide': this.infoDataMode === InfoModeEmployer.Created,
           },
           {
-            'info_bg-yellow': this.infoDataMode === InfoModeE.WaitWorker,
+            'info_bg-yellow': this.infoDataMode === InfoModeEmployer.WaitWorker,
           },
           {
-            'info_bg-green': this.infoDataMode === InfoModeE.Active,
+            'info_bg-green': this.infoDataMode === InfoModeEmployer.Active,
           },
           {
-            'info_bg-grey': this.infoDataMode === InfoModeE.WaitConfirm,
+            'info_bg-grey': this.infoDataMode === InfoModeEmployer.WaitConfirm,
           },
           {
-            'info_bg-red': this.infoDataMode === InfoModeE.Dispute,
+            'info_bg-red': this.infoDataMode === InfoModeEmployer.Dispute,
           },
           {
-            'info_bg-blue': [InfoModeE.Closed, InfoModeE.Done].includes(this.infoDataMode),
+            'info_bg-blue': [InfoModeEmployer.Closed, InfoModeEmployer.Done].includes(this.infoDataMode),
           },
         ];
       }

--- a/components/app/info/index.vue
+++ b/components/app/info/index.vue
@@ -1,64 +1,55 @@
 <template>
-  <div>
-    <span v-if="['employer'].includes(userRole)">
-      <span v-if="![1,3,5].includes(infoDataMode)">
+  <div
+    class="info"
+    :class="infoClass"
+  >
+    <div
+      v-if="userRole === 'employer' && ![1,3,5].includes(infoDataMode)"
+      class="info__body"
+    >
+      <div class="info__left">
         <div
-          class="info"
-          :class="infoClass"
+          class="info__text"
+          :class="[
+            {'info__text_white': ![3,6,7].includes(infoDataMode)}
+          ]"
         >
-          <div class="info__body">
-            <div class="info__left">
-              <div
-                class="info__text"
-                :class="[
-                  {'info__text_white': ![3,6,7].includes(infoDataMode)}
-                ]"
-              >
-                {{ infoStatusText }}
-              </div>
-            </div>
-          </div>
-        </div>
-      </span>
-    </span>
-    <span v-if="['worker'].includes(userRole)">
-      <div>
-        <div
-          class="info"
-          :class="infoClass"
-        >
-          <div class="info__body">
-            <div class="info__left">
-              <div
-                class="info__text"
-                :class="[
-                  {
-                    'info__text_white': ![3,7,8].includes(infoDataMode)
-                  },
-                  {
-                    'info__text_black': [3,7,8].includes(infoDataMode)
-                  }
-                ]"
-              >
-                {{ infoStatusText }}
-              </div>
-            </div>
-            <div class="info__right">
-              <div
-                v-if="[3].includes(infoDataMode)"
-              >
-                <base-btn mode="showYourMessage">
-                  <template v-slot:right>
-                    <span class="icon-caret_down" />
-                  </template>
-                  {{ $t('info.showYourMessage') }}
-                </base-btn>
-              </div>
-            </div>
-          </div>
+          {{ infoStatusText }}
         </div>
       </div>
-    </span>
+    </div>
+    <div
+      v-if="userRole === 'worker'"
+      class="info__body"
+    >
+      <div class="info__left">
+        <div
+          class="info__text"
+          :class="[
+            {
+              'info__text_white': ![3,7,8].includes(infoDataMode)
+            },
+            {
+              'info__text_black': [3,7,8].includes(infoDataMode)
+            }
+          ]"
+        >
+          {{ infoStatusText }}
+        </div>
+      </div>
+      <div class="info__right">
+        <div
+          v-if="[3].includes(infoDataMode)"
+        >
+          <base-btn mode="showYourMessage">
+            <template v-slot:right>
+              <span class="icon-caret_down" />
+            </template>
+            {{ $t('info.showYourMessage') }}
+          </base-btn>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -76,33 +67,28 @@ export default {
   },
   computed: {
     infoStatusText() {
-      if (['employer'].includes(this.userRole)) {
-        if ([2].includes(this.infoDataMode)) {
-          return this.$t('quests.activeQuest');
-        } if ([4].includes(this.infoDataMode)) {
-          return this.$t('quests.waitWorker');
-        } if ([6].includes(this.infoDataMode)) {
-          return this.$t('quests.pendingConsideration');
-        } if ([8, 9].includes(this.infoDataMode)) {
-          return this.$t('performed.title');
-        } if ([7].includes(this.infoDataMode)) {
-          return this.$t('quests.dispute');
-        }
+      if (this.userRole === 'employer') {
+        const obj = {
+          2: 'quests.activeQuest',
+          4: 'quests.waitWorker',
+          6: 'quests.pendingConsideration',
+          7: 'quests.dispute',
+          8: 'performed.title',
+          9: 'performed.title',
+        };
+        return this.$t(`${obj[this.infoDataMode]}`);
       }
-      if (['worker'].includes(this.userRole)) {
-        if ([1].includes(this.infoDataMode)) {
-          return this.$t('invite.title');
-        } if ([2].includes(this.infoDataMode)) {
-          return this.$t('quests.activeQuest');
-        } if ([3].includes(this.infoDataMode)) {
-          return this.$t('response.title');
-        } if ([4, 9].includes(this.infoDataMode)) {
-          return this.$t('quests.completed');
-        } if ([8].includes(this.infoDataMode)) {
-          return this.$t('quests.questClosed');
-        } if ([7].includes(this.infoDataMode)) {
-          return this.$t('quests.dispute');
-        }
+      if (this.userRole === 'worker') {
+        const obj = {
+          1: 'invite.title',
+          2: 'quests.activeQuest',
+          3: 'response.title',
+          4: 'quests.completed',
+          7: 'quests.dispute',
+          8: 'quests.questClosed',
+          9: 'quests.completed',
+        };
+        return this.$t(`${obj[this.infoDataMode]}`);
       }
       return '';
     },
@@ -128,24 +114,6 @@ export default {
       userData: 'user/getUserData',
       infoDataMode: 'quests/getInfoDataMode',
     }),
-  },
-  methods: {
-    infoText(type) {
-      const texts = {
-        invited: this.$t('invite.title'),
-        response: this.$t('response.title'),
-        active: this.$t('quests.activeQuest'),
-        performed: this.$t('performed.title'),
-      };
-      return texts[type] || '';
-    },
-    infoTextStyle() {
-      return [
-        {
-          info_yellow: [1].includes(this.infoDataMode),
-        },
-      ];
-    },
   },
 };
 

--- a/components/app/pages/common/quests.vue
+++ b/components/app/pages/common/quests.vue
@@ -151,7 +151,7 @@
                 >
                   <div class="block__rating block__rating_star">
                     <button
-                      @click="showReviewModal()"
+                      @click="showReviewModal(item)"
                     >
                       <star-rating :rating="item.user.ratingStatistic" />
                     </button>
@@ -324,7 +324,7 @@
                 >
                   <div class="block__rating block__rating_star">
                     <button
-                      @click="showReviewModal()"
+                      @click="showReviewModal(item)"
                     >
                       <star-rating :rating="item.user.ratingStatistic" />
                     </button>
@@ -473,10 +473,10 @@ export default {
     showDetails(questId) {
       this.$router.push(`/quests/${questId}`);
     },
-    showReviewModal(rating) {
+    showReviewModal(item) {
       this.ShowModal({
         key: modals.review,
-        rating,
+        item,
       });
     },
     isHideStar(type) {

--- a/components/app/pages/common/quests.vue
+++ b/components/app/pages/common/quests.vue
@@ -324,13 +324,10 @@
                   class="block__rating"
                 >
                   <div class="block__rating block__rating_star">
-                    <!--                    TODO: Исправить код оценки квеста-->
                     <button
                       @click="showReviewModal(item.user.ratingStatistic)"
                     >
-                      <b-form-rating
-                        v-model="ratingStatistic"
-                      />
+                      <star-rating />
                     </button>
                   </div>
                 </div>

--- a/components/app/pages/common/quests.vue
+++ b/components/app/pages/common/quests.vue
@@ -151,11 +151,9 @@
                 >
                   <div class="block__rating block__rating_star">
                     <button
-                      @click="showReviewModal(item.quest.user.ratingStatistic)"
+                      @click="showReviewModal()"
                     >
-                      <b-form-rating
-                        v-model="item.quest.user.ratingStatistic"
-                      />
+                      <star-rating :rating="item.user.ratingStatistic" />
                     </button>
                   </div>
                 </div>
@@ -326,9 +324,9 @@
                 >
                   <div class="block__rating block__rating_star">
                     <button
-                      @click="showReviewModal(item.user.ratingStatistic)"
+                      @click="showReviewModal()"
                     >
-                      <star-rating />
+                      <star-rating :rating="item.user.ratingStatistic" />
                     </button>
                   </div>
                 </div>

--- a/components/app/pages/common/quests.vue
+++ b/components/app/pages/common/quests.vue
@@ -342,7 +342,7 @@
 <script>
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
-import { QStatuses, questPriority, questsCompPageMode } from '~/utils/enums';
+import { QuestStatuses, questPriority, questsCompPageMode } from '~/utils/enums';
 import modals from '~/store/modals/modals';
 
 const value = new Vue();
@@ -383,7 +383,7 @@ export default {
       userData: 'user/getUserData',
     }),
     questStatuses() {
-      return QStatuses;
+      return QuestStatuses;
     },
     questsComponentPageMode() {
       return questsCompPageMode;
@@ -433,17 +433,17 @@ export default {
     },
     progressQuestText(status) {
       if (this.userRole) {
-        if (status === QStatuses.Active) {
+        if (status === QuestStatuses.Active) {
           return this.$t('quests.questActive:');
-        } if (status === QStatuses.Closed) {
+        } if (status === QuestStatuses.Closed) {
           return this.$t('quests.questClosed:');
-        } if (status === QStatuses.Dispute) {
+        } if (status === QuestStatuses.Dispute) {
           return this.$t('questDispute:');
-        } if (status === QStatuses.WaitWorker) {
+        } if (status === QuestStatuses.WaitWorker) {
           return this.$t('quests.inProgressBy');
-        } if (status === QStatuses.WaitConfirm) {
+        } if (status === QuestStatuses.WaitConfirm) {
           return this.$t('questWaitConfirm:');
-        } if (status === QStatuses.Done) {
+        } if (status === QuestStatuses.Done) {
           return this.$t('quests.finishedBy');
         }
       }
@@ -495,23 +495,23 @@ export default {
     },
     getStatusCard(index) {
       const questStatus = {
-        [QStatuses.Rejected]: 'Rejected',
-        [QStatuses.Active]: this.$t('quests.active'),
-        [QStatuses.Done]: this.$t('quests.performed'),
-        [QStatuses.WaitConfirm]: this.$t('quests.requested'),
-        [QStatuses.WaitWorker]: this.$t('quests.invited'),
-        [QStatuses.Closed]: this.$t('quests.closed'),
+        [QuestStatuses.Rejected]: this.$t('quests.rejected'),
+        [QuestStatuses.Active]: this.$t('quests.active'),
+        [QuestStatuses.Done]: this.$t('quests.performed'),
+        [QuestStatuses.WaitConfirm]: this.$t('quests.requested'),
+        [QuestStatuses.WaitWorker]: this.$t('quests.invited'),
+        [QuestStatuses.Closed]: this.$t('quests.closed'),
       };
       return questStatus[index] || '';
     },
     getStatusClass(index) {
       const questStatus = {
-        [QStatuses.Rejected]: 'quests__cards__state_clo',
-        [QStatuses.Active]: 'quests__cards__state_act',
-        [QStatuses.Done]: 'quests__cards__state_per',
-        [QStatuses.WaitConfirm]: 'quests__cards__state_req',
-        [QStatuses.WaitWorker]: 'quests__cards__state_inv',
-        [QStatuses.Closed]: 'quests__cards__state_clo',
+        [QuestStatuses.Rejected]: 'quests__cards__state_clo',
+        [QuestStatuses.Active]: 'quests__cards__state_act',
+        [QuestStatuses.Done]: 'quests__cards__state_per',
+        [QuestStatuses.WaitConfirm]: 'quests__cards__state_req',
+        [QuestStatuses.WaitWorker]: 'quests__cards__state_inv',
+        [QuestStatuses.Closed]: 'quests__cards__state_clo',
       };
       return questStatus[index] || '';
     },

--- a/components/app/pages/common/quests.vue
+++ b/components/app/pages/common/quests.vue
@@ -3,7 +3,7 @@
     class="quests"
   >
     <div
-      v-if="[1].includes(pageMode)"
+      v-if="pageMode === questsComponentPageMode.WorkerMy"
       class="quests__card card"
     >
       <div
@@ -166,7 +166,8 @@
       </div>
     </div>
     <div
-      v-if="[2,3,4].includes(pageMode)"
+      v-if="[questsComponentPageMode.WorkerOther,
+             questsComponentPageMode.EmpMy, questsComponentPageMode.EmpOther].includes(pageMode)"
       class="quests__card card"
     >
       <div
@@ -213,12 +214,12 @@
                 </div>
               </div>
               <quest-dd
-                v-if="[0].includes(item.status)"
+                v-if="item.status === questStatuses.Created"
                 class="block__icon block__icon_fav"
                 mode="vertical"
               />
               <div
-                v-if="[2,3].includes(item.status)"
+                v-if="[questStatuses.Closed, questStatuses.Dispute].includes(item.status)"
                 class="block__icon block__icon_fav star"
                 @click="setStar(item)"
               >
@@ -320,7 +321,7 @@
                   </template>
                 </base-btn>
                 <div
-                  v-if="[6].includes(item.status)"
+                  v-if="item.status === questStatuses.Done"
                   class="block__rating"
                 >
                   <div class="block__rating block__rating_star">
@@ -343,6 +344,7 @@
 <script>
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
+import { QStatuses, questPriority, questsCompPageMode } from '~/utils/enums';
 import modals from '~/store/modals/modals';
 
 const value = new Vue();
@@ -382,24 +384,30 @@ export default {
       userRole: 'user/getUserRole',
       userData: 'user/getUserData',
     }),
+    questStatuses() {
+      return QStatuses;
+    },
+    questsComponentPageMode() {
+      return questsCompPageMode;
+    },
     pageMode() {
       if (this.userRole === 'worker') {
         if (this.$route.path === '/my') {
-          return 1;
+          return questsCompPageMode.WorkerMy;
         }
         if (this.$route.path !== '/my') {
-          return 2;
+          return questsCompPageMode.WorkerOther;
         }
       }
       if (this.userRole === 'employer') {
         if (this.$route.path === '/my') {
-          return 3;
+          return questsCompPageMode.EmpMy;
         }
         if (this.$route.path !== '/my') {
-          return 4;
+          return questsCompPageMode.EmpOther;
         }
       }
-      return 0;
+      return '';
     },
     userCompany() {
       return this.userData.additionalInfo?.company || null;
@@ -427,17 +435,17 @@ export default {
     },
     progressQuestText(status) {
       if (this.userRole) {
-        if ([1].includes(status)) {
+        if (status === QStatuses.Active) {
           return this.$t('quests.questActive:');
-        } if ([2].includes(status)) {
+        } if (status === QStatuses.Closed) {
           return this.$t('quests.questClosed:');
-        } if ([3].includes(status)) {
+        } if (status === QStatuses.Dispute) {
           return this.$t('questDispute:');
-        } if ([4].includes(status)) {
+        } if (status === QStatuses.WaitWorker) {
           return this.$t('quests.inProgressBy');
-        } if ([5].includes(status)) {
+        } if (status === QStatuses.WaitConfirm) {
           return this.$t('questWaitConfirm:');
-        } if ([6].includes(status)) {
+        } if (status === QStatuses.Done) {
           return this.$t('quests.finishedBy');
         }
       }
@@ -488,42 +496,40 @@ export default {
       });
     },
     getStatusCard(index) {
-      const status = {
-        '-1': 'Rejected',
-        1: this.$t('quests.active'),
-        6: this.$t('quests.performed'),
-        5: this.$t('quests.requested'),
-        4: this.$t('quests.invited'),
-        2: this.$t('quests.closed'),
+      const questStatus = {
+        [QStatuses.Rejected]: 'Rejected',
+        [QStatuses.Active]: this.$t('quests.active'),
+        [QStatuses.Done]: this.$t('quests.performed'),
+        [QStatuses.WaitConfirm]: this.$t('quests.requested'),
+        [QStatuses.WaitWorker]: this.$t('quests.invited'),
+        [QStatuses.Closed]: this.$t('quests.closed'),
       };
-      return status[index] || '';
+      return questStatus[index] || '';
     },
     getStatusClass(index) {
-      const status = {
-        '-1': 'quests__cards__state_clo',
-        1: 'quests__cards__state_act',
-        6: 'quests__cards__state_per',
-        5: 'quests__cards__state_req',
-        4: 'quests__cards__state_inv',
-        2: 'quests__cards__state_clo',
+      const questStatus = {
+        [QStatuses.Rejected]: 'quests__cards__state_clo',
+        [QStatuses.Active]: 'quests__cards__state_act',
+        [QStatuses.Done]: 'quests__cards__state_per',
+        [QStatuses.WaitConfirm]: 'quests__cards__state_req',
+        [QStatuses.WaitWorker]: 'quests__cards__state_inv',
+        [QStatuses.Closed]: 'quests__cards__state_clo',
       };
-      return status[index] || '';
+      return questStatus[index] || '';
     },
     getPriority(index) {
       const priority = {
-        0: '',
-        1: this.$t('priority.low'),
-        2: this.$t('priority.normal'),
-        3: this.$t('priority.urgent'),
+        [questPriority.Low]: this.$t('priority.low'),
+        [questPriority.Normal]: this.$t('priority.normal'),
+        [questPriority.Urgent]: this.$t('priority.urgent'),
       };
       return priority[index] || '';
     },
     getPriorityClass(index) {
       const priority = {
-        0: '',
-        1: 'block__priority_low',
-        2: 'block__priority_normal',
-        3: 'block__priority_urgent',
+        [questPriority.Low]: 'block__priority_low',
+        [questPriority.Normal]: 'block__priority_normal',
+        [questPriority.Urgent]: 'block__priority_urgent',
       };
       return priority[index] || '';
     },

--- a/components/app/pages/quests_id/employer.vue
+++ b/components/app/pages/quests_id/employer.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="userRole === 'employer'">
     <div
-      v-if="[1].includes(infoDataMode)"
+      v-if="infoDataMode === InfoModeEmployer.RaiseViews"
       class="btns__container"
     >
       <div
@@ -24,7 +24,7 @@
         </div>
       </div>
     </div>
-    <div v-if="[2].includes(infoDataMode)">
+    <div v-if="infoDataMode === InfoModeEmployer.Active">
       <div class="worker__title">
         {{ $t('quests.worker') }}
       </div>
@@ -101,7 +101,7 @@
     <!--                </div>-->
     <!--              </div>-->
     <!--    </div>-->
-    <div v-if="[4].includes(infoDataMode)">
+    <div v-if="infoDataMode === InfoModeEmployer.WaitWorker">
       <div
         class="worker__title"
       >
@@ -135,7 +135,7 @@
       </div>
     </div>
     <div
-      v-if="[6].includes(infoDataMode)"
+      v-if="infoDataMode === InfoModeEmployer.WaitConfirm"
       class="btns__container"
     >
       <div>
@@ -191,7 +191,7 @@
         </div>
       </div>
     </div>
-    <div v-if="[7, 8].includes(infoDataMode)">
+    <div v-if="[InfoModeEmployer.Dispute, InfoModeEmployer.Closed].includes(infoDataMode)">
       <div class="worker__title">
         {{ $t('quests.worker') }}
       </div>
@@ -221,7 +221,7 @@
       </div>
       <div class="btns__container">
         <div
-          v-if="[7].includes(infoDataMode)"
+          v-if="infoDataMode === InfoModeEmployer.Dispute"
           class="btns__wrapper"
         >
           <div class="btn__wrapper">
@@ -232,7 +232,7 @@
         </div>
       </div>
     </div>
-    <div v-if="[9].includes(infoDataMode)">
+    <div v-if="infoDataMode === InfoModeEmployer.Done">
       <div class="worker__title">
         {{ $t('quests.worker') }}
       </div>
@@ -262,7 +262,7 @@
       </div>
     </div>
     <div
-      v-if="![4,8,9].includes(infoDataMode)"
+      v-if="![InfoModeEmployer.WaitWorker, InfoModeEmployer.Closed, InfoModeEmployer.Done].includes(infoDataMode)"
       class="btns__container"
     >
       <div class="priority">
@@ -291,6 +291,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import modals from '~/store/modals/modals';
+import { InfoModeE } from '~/utils/enums';
 
 export default {
   name: 'QuestIdEmployer',
@@ -325,6 +326,9 @@ export default {
       responsesToQuest: 'quests/getResponsesToQuest',
       infoDataMode: 'quests/getInfoDataMode',
     }),
+    InfoModeEmployer() {
+      return InfoModeE;
+    },
     cardBadgeLevel() {
       return [
         {
@@ -377,7 +381,7 @@ export default {
     },
     async closeQuest() {
       this.SetLoader(true);
-      if (this.questData.status !== 2) {
+      if (this.questData.status !== InfoModeE.Active) {
         await this.$store.dispatch('quests/closeQuest', this.questData.id);
       }
       this.ShowModal({
@@ -398,7 +402,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.completedWorkAccepted'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', 9);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeE.Done);
       this.SetLoader(false);
     },
     async rejectCompletedWorkOnQuest() {
@@ -410,7 +414,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.completedWorkRejected'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', 7);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeE.Dispute);
       this.SetLoader(false);
     },
     async initData() {

--- a/components/app/pages/quests_id/employer.vue
+++ b/components/app/pages/quests_id/employer.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="['employer'].includes(userRole)">
+  <div v-if="userRole === 'employer'">
     <div
       v-if="[1].includes(infoDataMode)"
       class="btns__container"
@@ -25,27 +25,21 @@
       </div>
     </div>
     <div v-if="[2].includes(infoDataMode)">
-      <div class="worker__title">{{ $t('quests.worker') }}</div>
+      <div class="worker__title">
+        {{ $t('quests.worker') }}
+      </div>
       <div class="worker__container">
         <div>
           <img
-            v-if="assignWorker"
             class="worker__avatar"
-            :src="userAvatar"
-            alt=""
-          >
-          <img
-            v-if="!assignWorker"
-            class="worker__avatar"
-            :src="require('~/assets/img/app/avatar_empty.png')"
+            :src="userAvatar ? userAvatar : require('~/assets/img/app/avatar_empty.png')"
             alt=""
           >
         </div>
         <div
-          v-if="assignWorker"
           class="worker__name"
         >
-          {{ assignWorker.firstName ? assignWorker.firstName : 'Nameless' }} {{ assignWorker.lastName ? assignWorker.lastName : '' }}
+          {{ assignWorker ? assignWorker.firstName : 'Nameless' }} {{ assignWorker ? assignWorker.lastName : '' }}
         </div>
         <div>
           <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА Нет Бэка-->
@@ -109,26 +103,24 @@
     <!--    </div>-->
     <div v-if="[4].includes(infoDataMode)">
       <div
-        v-if="assignWorker"
         class="worker__title"
       >
         {{ $t('quests.worker') }}
       </div>
       <div
-        v-if="assignWorker"
-        class="worker__container"
+        class="worker__container_row"
       >
         <div>
           <img
             class="worker__avatar"
-            :src="assignWorker.avatar ? assignWorker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
+            :src="userAvatar ? userAvatar : require('~/assets/img/app/avatar_empty.png')"
             alt=""
           >
         </div>
         <div
           class="worker__name"
         >
-          {{ assignWorker.firstName ? assignWorker.firstName : 'Nameless' }} {{ assignWorker.lastName ? assignWorker.lastName : '' }}
+          {{ assignWorker ? assignWorker.firstName : 'Nameless' }} {{ assignWorker ? assignWorker.lastName : '' }}
         </div>
         <div>
           <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка-->
@@ -152,22 +144,14 @@
         </div>
         <div class="worker__container_row">
           <img
-            v-if="assignWorker"
             class="worker__avatar"
-            :src="userAvatar"
-            alt=""
-          >
-          <img
-            v-if="!assignWorker"
-            class="worker__avatar"
-            :src="require('~/assets/img/app/avatar_empty.png')"
+            :src="userAvatar ? userAvatar : require('~/assets/img/app/avatar_empty.png')"
             alt=""
           >
           <div
-            v-if="assignWorker"
             class="worker__name"
           >
-            {{ assignWorker.firstName ? assignWorker.firstName : 'Nameless' }} {{ assignWorker.lastName ? assignWorker.lastName : '' }}
+            {{ assignWorker ? assignWorker.firstName : 'Nameless' }} {{ assignWorker ? assignWorker.lastName : '' }}
           </div>
           <div>
             <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА-->
@@ -207,30 +191,22 @@
         </div>
       </div>
     </div>
-    <div v-if="[7].includes(infoDataMode)">
+    <div v-if="[7, 8].includes(infoDataMode)">
       <div class="worker__title">
         {{ $t('quests.worker') }}
       </div>
-      <div class="worker__container">
+      <div class="worker__container_row">
         <div>
           <img
-            v-if="assignWorker"
             class="worker__avatar"
-            :src="userAvatar"
-            alt=""
-          >
-          <img
-            v-if="!assignWorker"
-            class="worker__avatar"
-            :src="require('~/assets/img/app/avatar_empty.png')"
+            :src="userAvatar ? userAvatar : require('~/assets/img/app/avatar_empty.png')"
             alt=""
           >
         </div>
         <div
-          v-if="assignWorker"
           class="worker__name"
         >
-          {{ assignWorker.firstName ? assignWorker.firstName : 'Nameless' }} {{ assignWorker.lastName ? assignWorker.lastName : '' }}
+          {{ assignWorker ? assignWorker.firstName : 'Nameless' }} {{ assignWorker ? assignWorker.lastName : '' }}
         </div>
         <div>
           <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка-->
@@ -263,23 +239,15 @@
       <div class="worker__container_row">
         <div>
           <img
-            v-if="assignWorker"
             class="worker__avatar"
-            :src="userAvatar"
-            alt=""
-          >
-          <img
-            v-if="!assignWorker"
-            class="worker__avatar"
-            :src="require('~/assets/img/app/avatar_empty.png')"
+            :src="userAvatar ? userAvatar : require('~/assets/img/app/avatar_empty.png')"
             alt=""
           >
         </div>
         <div
-          v-if="assignWorker"
           class="worker__name"
         >
-          {{ assignWorker.firstName ? assignWorker.firstName : 'Nameless' }} {{ assignWorker.lastName ? assignWorker.lastName : '' }}
+          {{ assignWorker ? assignWorker.firstName : 'Nameless' }} {{ assignWorker ? assignWorker.lastName : '' }}
         </div>
         <div>
           <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка-->
@@ -317,7 +285,7 @@
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </template>
 
 <script>

--- a/components/app/pages/quests_id/employer.vue
+++ b/components/app/pages/quests_id/employer.vue
@@ -291,7 +291,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import modals from '~/store/modals/modals';
-import { InfoModeE } from '~/utils/enums';
+import { InfoModeEmployer } from '~/utils/enums';
 
 export default {
   name: 'QuestIdEmployer',
@@ -327,7 +327,7 @@ export default {
       infoDataMode: 'quests/getInfoDataMode',
     }),
     InfoModeEmployer() {
-      return InfoModeE;
+      return InfoModeEmployer;
     },
     cardBadgeLevel() {
       return [
@@ -381,7 +381,7 @@ export default {
     },
     async closeQuest() {
       this.SetLoader(true);
-      if (this.questData.status !== InfoModeE.Active) {
+      if (this.questData.status !== InfoModeEmployer.Active) {
         await this.$store.dispatch('quests/closeQuest', this.questData.id);
         this.showModalQuestClosed();
       }
@@ -392,14 +392,14 @@ export default {
       this.SetLoader(true);
       await this.$store.dispatch('quests/acceptCompletedWorkOnQuest', this.questData.id);
       this.showModalQuestCompletedWorkAccepted();
-      await this.$store.dispatch('quests/setInfoDataMode', InfoModeE.Done);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeEmployer.Done);
       this.SetLoader(false);
     },
     async rejectCompletedWorkOnQuest() {
       this.SetLoader(true);
       await this.$store.dispatch('quests/rejectCompletedWorkOnQuest', this.questData.id);
       this.showModalRejectCompletedWorkOnQuest();
-      await this.$store.dispatch('quests/setInfoDataMode', InfoModeE.Dispute);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeEmployer.Dispute);
       this.SetLoader(false);
     },
     async initData() {

--- a/components/app/pages/quests_id/employer.vue
+++ b/components/app/pages/quests_id/employer.vue
@@ -410,7 +410,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.completedWorkRejected'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', 9);
+      await this.$store.dispatch('quests/setInfoDataMode', 7);
       this.SetLoader(false);
     },
     async initData() {

--- a/components/app/pages/quests_id/employer.vue
+++ b/components/app/pages/quests_id/employer.vue
@@ -383,37 +383,22 @@ export default {
       this.SetLoader(true);
       if (this.questData.status !== InfoModeE.Active) {
         await this.$store.dispatch('quests/closeQuest', this.questData.id);
+        this.showModalQuestClosed();
       }
-      this.ShowModal({
-        key: modals.status,
-        img: require('~/assets/img/ui/questAgreed.svg'),
-        title: this.$t('quests.questInfo'),
-        subtitle: this.$t('quests.questClosed!'),
-      });
       await this.$router.push('/my');
       this.SetLoader(false);
     },
     async acceptCompletedWorkOnQuest() {
       this.SetLoader(true);
       await this.$store.dispatch('quests/acceptCompletedWorkOnQuest', this.questData.id);
-      this.ShowModal({
-        key: modals.status,
-        img: require('~/assets/img/ui/questAgreed.svg'),
-        title: this.$t('quests.questInfo'),
-        subtitle: this.$t('quests.completedWorkAccepted'),
-      });
+      this.showModalQuestCompletedWorkAccepted();
       await this.$store.dispatch('quests/setInfoDataMode', InfoModeE.Done);
       this.SetLoader(false);
     },
     async rejectCompletedWorkOnQuest() {
       this.SetLoader(true);
       await this.$store.dispatch('quests/rejectCompletedWorkOnQuest', this.questData.id);
-      this.ShowModal({
-        key: modals.status,
-        img: require('~/assets/img/ui/questAgreed.svg'),
-        title: this.$t('quests.questInfo'),
-        subtitle: this.$t('quests.completedWorkRejected'),
-      });
+      this.showModalRejectCompletedWorkOnQuest();
       await this.$store.dispatch('quests/setInfoDataMode', InfoModeE.Dispute);
       this.SetLoader(false);
     },
@@ -435,6 +420,30 @@ export default {
     toRaisingViews() {
       this.$router.push('/edit-quest');
       this.$store.dispatch('quests/getCurrentStepEditQuest', 2);
+    },
+    showModalRejectCompletedWorkOnQuest() {
+      this.ShowModal({
+        key: modals.status,
+        img: require('~/assets/img/ui/questAgreed.svg'),
+        title: this.$t('quests.questInfo'),
+        subtitle: this.$t('quests.completedWorkRejected'),
+      });
+    },
+    showModalQuestCompletedWorkAccepted() {
+      this.ShowModal({
+        key: modals.status,
+        img: require('~/assets/img/ui/questAgreed.svg'),
+        title: this.$t('quests.questInfo'),
+        subtitle: this.$t('quests.completedWorkAccepted'),
+      });
+    },
+    showModalQuestClosed() {
+      this.ShowModal({
+        key: modals.status,
+        img: require('~/assets/img/ui/questAgreed.svg'),
+        title: this.$t('quests.questInfo'),
+        subtitle: this.$t('quests.questClosed!'),
+      });
     },
   },
 };

--- a/components/app/pages/quests_id/employer.vue
+++ b/components/app/pages/quests_id/employer.vue
@@ -380,25 +380,28 @@ export default {
       return priority[index] || '';
     },
     async closeQuest() {
+      const modalMode = 1;
       this.SetLoader(true);
       if (this.questData.status !== InfoModeEmployer.Active) {
         await this.$store.dispatch('quests/closeQuest', this.questData.id);
-        this.showModalQuestClosed();
+        this.showQuestModal(modalMode);
       }
       await this.$router.push('/my');
       this.SetLoader(false);
     },
     async acceptCompletedWorkOnQuest() {
+      const modalMode = 2;
       this.SetLoader(true);
       await this.$store.dispatch('quests/acceptCompletedWorkOnQuest', this.questData.id);
-      this.showModalQuestCompletedWorkAccepted();
+      this.showQuestModal(modalMode);
       await this.$store.dispatch('quests/setInfoDataMode', InfoModeEmployer.Done);
       this.SetLoader(false);
     },
     async rejectCompletedWorkOnQuest() {
+      const modalMode = 3;
       this.SetLoader(true);
       await this.$store.dispatch('quests/rejectCompletedWorkOnQuest', this.questData.id);
-      this.showModalRejectCompletedWorkOnQuest();
+      this.showQuestModal(modalMode);
       await this.$store.dispatch('quests/setInfoDataMode', InfoModeEmployer.Dispute);
       this.SetLoader(false);
     },
@@ -421,29 +424,21 @@ export default {
       this.$router.push('/edit-quest');
       this.$store.dispatch('quests/getCurrentStepEditQuest', 2);
     },
-    showModalRejectCompletedWorkOnQuest() {
+    showQuestModal(modalMode) {
       this.ShowModal({
         key: modals.status,
         img: require('~/assets/img/ui/questAgreed.svg'),
         title: this.$t('quests.questInfo'),
-        subtitle: this.$t('quests.completedWorkRejected'),
+        subtitle: this.modalMode(modalMode),
       });
     },
-    showModalQuestCompletedWorkAccepted() {
-      this.ShowModal({
-        key: modals.status,
-        img: require('~/assets/img/ui/questAgreed.svg'),
-        title: this.$t('quests.questInfo'),
-        subtitle: this.$t('quests.completedWorkAccepted'),
-      });
-    },
-    showModalQuestClosed() {
-      this.ShowModal({
-        key: modals.status,
-        img: require('~/assets/img/ui/questAgreed.svg'),
-        title: this.$t('quests.questInfo'),
-        subtitle: this.$t('quests.questClosed!'),
-      });
+    modalMode(modalMode) {
+      const subtitles = {
+        1: this.$t('quests.questClosed!'),
+        2: this.$t('quests.completedWorkAccepted'),
+        3: this.$t('quests.completedWorkRejected'),
+      };
+      return subtitles[modalMode];
     },
   },
 };

--- a/components/app/pages/quests_id/invitedWorkerList.vue
+++ b/components/app/pages/quests_id/invitedWorkerList.vue
@@ -1,10 +1,12 @@
 <template>
   <!--      TODO: Вывести список Invited!-->
   <div class="worker worker__card">
-    <div class="worker__title worker__col_two">
-      <div>{{ $t('quests.invited') }}</div>
+    <div class="worker__cols-two">
+      <div class="worker__title">
+        {{ $t('quests.invited') }}
+      </div>
       <div
-        class="btns__wrapper"
+        class="btns__wrapper btns__start"
       >
         <div class="btn__wrapper">
           <base-btn
@@ -16,64 +18,72 @@
           </base-btn>
         </div>
       </div>
-      <div style="margin: 15px 0 0 15px; padding: 0 0 15px 0; color: #7C838DFF; font-size: 16px;">
-        Workers not invited!
+    </div>
+    <div
+      v-if="filteredInvited.length === 0"
+      style="margin: 15px 0 0 15px; padding: 0 0 15px 0; color: #7C838DFF; font-size: 16px;"
+    >
+      Workers not invited!
+    </div>
+    <div
+      v-if="filteredInvited.length"
+      class="invited__list"
+    >
+      <div
+        v-for="(response, i) in filteredInvited"
+        :key="i"
+        class="invited__response"
+      >
+        <div
+          v-if="response.worker.firstName && response.worker.lastName"
+          class="worker__container"
+        >
+          <div class="worker worker__col_two">
+            <div class="worker row">
+              <img
+                class="worker__avatar"
+                :src="response.worker.avatar ? response.worker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
+                alt=""
+              >
+              <div
+                class="worker__name"
+              >
+                {{ response.worker.firstName }} {{ response.worker.lastName }}
+              </div>
+            </div>
+            <quest-id-dd
+              class="worker__menu"
+              :i="i"
+              :response-id="response.id"
+            />
+          </div>
+          <div class="worker__message">
+            {{ response.message }}
+          </div>
+          <div>
+            <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка-->
+            <!--                    <div-->
+            <!--                      v-if="item.badge.code !== 0"-->
+            <!--                      class="card__level_higher"-->
+            <!--                      :class="[-->
+            <!--                        {'card__level_higher': item.badge.code === 1},-->
+            <!--                        {'card__level_reliable': item.badge.code === 2},-->
+            <!--                        {'card__level_checked': item.badge.code === 3}-->
+            <!--                      ]"-->
+            <!--                    >-->
+            <!--                      <span v-if="item.badge.code === 1">-->
+            <!--                        {{ $t('levels.higher') }}-->
+            <!--                      </span>-->
+            <!--                      <span v-if="item.badge.code === 2">-->
+            <!--                        {{ $t('levels.reliableEmp') }}-->
+            <!--                      </span>-->
+            <!--                      <span v-if="item.badge.code === 3">-->
+            <!--                        {{ $t('levels.checkedByTime') }}-->
+            <!--                      </span>-->
+            <!--                    </div>-->
+          </div>
+        </div>
       </div>
-      <!--        <span v-if="filteredResponses.length">-->
-      <!--          <span-->
-      <!--            v-for="(response, i) in filteredResponses"-->
-      <!--            :key="i"-->
-      <!--          >-->
-      <!--            <div-->
-      <!--              v-if="response.worker.firstName && response.worker.lastName"-->
-      <!--              class="worker__container"-->
-      <!--            >-->
-      <!--              <div class="worker worker__col_two">-->
-      <!--                <div class="worker row">-->
-      <!--                  <img-->
-      <!--                    class="worker__avatar"-->
-      <!--                    :src="response.worker.avatar ? response.worker.avatar.url: require('~/assets/img/app/avatar_empty.png')"-->
-      <!--                    alt=""-->
-      <!--                  >-->
-      <!--                  <div-->
-      <!--                    class="worker__name"-->
-      <!--                  >-->
-      <!--                    {{ response.worker.firstName }} {{ response.worker.lastName }}-->
-      <!--                  </div>-->
-      <!--                </div>-->
-      <!--                <quest-id-dd-->
-      <!--                  :i="i"-->
-      <!--                  :response-id="response.id"-->
-      <!--                />-->
-      <!--              </div>-->
-      <!--              <div class="worker__message">-->
-      <!--                {{ response.message }}-->
-      <!--              </div>-->
-      <!--              <div>-->
-      <!--              &lt;!&ndash;                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка&ndash;&gt;-->
-      <!--              &lt;!&ndash;                    <div&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      v-if="item.badge.code !== 0"&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      class="card__level_higher"&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      :class="[&ndash;&gt;-->
-      <!--              &lt;!&ndash;                        {'card__level_higher': item.badge.code === 1},&ndash;&gt;-->
-      <!--              &lt;!&ndash;                        {'card__level_reliable': item.badge.code === 2},&ndash;&gt;-->
-      <!--              &lt;!&ndash;                        {'card__level_checked': item.badge.code === 3}&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      ]"&ndash;&gt;-->
-      <!--              &lt;!&ndash;                    >&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      <span v-if="item.badge.code === 1">&ndash;&gt;-->
-      <!--              &lt;!&ndash;                        {{ $t('levels.higher') }}&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      </span>&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      <span v-if="item.badge.code === 2">&ndash;&gt;-->
-      <!--              &lt;!&ndash;                        {{ $t('levels.reliableEmp') }}&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      </span>&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      <span v-if="item.badge.code === 3">&ndash;&gt;-->
-      <!--              &lt;!&ndash;                        {{ $t('levels.checkedByTime') }}&ndash;&gt;-->
-      <!--              &lt;!&ndash;                      </span>&ndash;&gt;-->
-      <!--              &lt;!&ndash;                    </div>&ndash;&gt;-->
-      <!--              </div>-->
-      <!--            </div>-->
-      <!--          </span>-->
-      <!--        </span>-->
     </div>
   </div>
 </template>
@@ -83,6 +93,12 @@ import { mapGetters } from 'vuex';
 
 export default {
   name: 'InvitedWorkerList',
+  props: {
+    filteredInvited: {
+      type: Array,
+      default: () => [],
+    },
+  },
   computed: {
     ...mapGetters({
       currentWorker: 'quests/getCurrentWorker',
@@ -113,6 +129,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.invited {
+  &__list {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+}
 .row {
   display: flex;
   flex-direction: row;
@@ -126,6 +149,7 @@ export default {
   }
   &__start {
     height: 43px;
+    margin: 15px 0 0 0;
   }
 }
 .btns {
@@ -133,16 +157,27 @@ export default {
     display: grid;
     margin-bottom: 20px;
   }
+  &__start {
+    justify-content: flex-end;
+  }
   &__wrapper {
     display: flex;
     flex-direction: row;
     align-items: center;
+    width: 100%;
   }
 }
 .worker {
   font-size: 16px;
   font-weight: 500;
   color: $black800;
+  &__menu {
+    justify-self: self-end;
+  }
+  &__cols-two {
+    display: grid;
+    grid-template-columns: 9fr 3fr;
+  }
    &__card {
     margin: 30px 0;
     background: $white;
@@ -156,11 +191,11 @@ export default {
  }
   &__col {
     &_two {
-      width: 100%;
       display: grid;
-      grid-template-columns: repeat(2, auto);
+      grid-template-columns: 11fr 1fr;
       justify-content: space-between;
-      align-items: center;
+      align-items: flex-start;
+      width: 100%;
     }
  }
   &__container_row {

--- a/components/app/pages/quests_id/invitedWorkerList.vue
+++ b/components/app/pages/quests_id/invitedWorkerList.vue
@@ -21,9 +21,9 @@
     </div>
     <div
       v-if="filteredInvited.length === 0"
-      style="margin: 15px 0 0 15px; padding: 0 0 15px 0; color: #7C838DFF; font-size: 16px;"
+      class="invited__title"
     >
-      Workers not invited!
+      {{ $t('quests.workersNotInvited') }}
     </div>
     <div
       v-if="filteredInvited.length"
@@ -130,6 +130,12 @@ export default {
 
 <style lang="scss" scoped>
 .invited {
+  &__title {
+    margin: 15px 0 0 15px;
+    padding: 0 0 15px 0;
+    color: #7C838DFF;
+    font-size: 16px;
+  }
   &__list {
     width: 100%;
     display: flex;

--- a/components/app/pages/quests_id/respondedWorkerList.vue
+++ b/components/app/pages/quests_id/respondedWorkerList.vue
@@ -9,65 +9,68 @@
       >
         {{ $t('response.title') }}
       </div>
-      <span v-if="filteredResponses.length > 0">
-        <span
+      <div class="worker__container">
+        <div
+          v-if="filteredResponses.length === 0"
+          class="info__message"
+        >
+          {{ $t('quests.employer.usersNotResponded') }}
+        </div>
+        <div
           v-for="(response, i) in filteredResponses"
           :key="i"
         >
           <div
-            v-if="response.worker.firstName && response.worker.lastName"
-            class="worker__container"
+            class="worker worker__col_two"
           >
-            <div class="worker worker__col_two">
-              <div class="worker row">
-                <img
-                  class="worker__avatar"
-                  :src="response.worker.avatar ? response.worker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
-                  alt=""
-                >
-                <div
-                  class="worker__name"
-                >
-                  {{ response.worker.firstName }} {{ response.worker.lastName }}
-                </div>
+            <div
+              v-if="response.worker.firstName && response.worker.lastName"
+              class="worker row"
+            >
+              <img
+                class="worker__avatar"
+                :src="response.worker.avatar ? response.worker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
+                alt=""
+              >
+              <div
+                class="worker__name"
+              >
+                {{ response.worker.firstName }} {{ response.worker.lastName }}
               </div>
-              <quest-id-dd
-                :i="i"
-                :response-id="response.id"
-              />
             </div>
+            <quest-id-dd
+              :i="i"
+              :response-id="response.id"
+            />
             <div class="worker__message">
               {{ response.message }}
             </div>
-            <div>
-              <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка-->
-              <!--                    <div-->
-              <!--                      v-if="item.badge.code !== 0"-->
-              <!--                      class="card__level_higher"-->
-              <!--                      :class="[-->
-              <!--                        {'card__level_higher': item.badge.code === 1},-->
-              <!--                        {'card__level_reliable': item.badge.code === 2},-->
-              <!--                        {'card__level_checked': item.badge.code === 3}-->
-              <!--                      ]"-->
-              <!--                    >-->
-              <!--                      <span v-if="item.badge.code === 1">-->
-              <!--                        {{ $t('levels.higher') }}-->
-              <!--                      </span>-->
-              <!--                      <span v-if="item.badge.code === 2">-->
-              <!--                        {{ $t('levels.reliableEmp') }}-->
-              <!--                      </span>-->
-              <!--                      <span v-if="item.badge.code === 3">-->
-              <!--                        {{ $t('levels.checkedByTime') }}-->
-              <!--                      </span>-->
-              <!--                    </div>-->
-            </div>
           </div>
-        </span>
-      </span>
+          <div>
+            <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка-->
+            <!--                    <div-->
+            <!--                      v-if="item.badge.code !== 0"-->
+            <!--                      class="card__level_higher"-->
+            <!--                      :class="[-->
+            <!--                        {'card__level_higher': item.badge.code === 1},-->
+            <!--                        {'card__level_reliable': item.badge.code === 2},-->
+            <!--                        {'card__level_checked': item.badge.code === 3}-->
+            <!--                      ]"-->
+            <!--                    >-->
+            <!--                      <span v-if="item.badge.code === 1">-->
+            <!--                        {{ $t('levels.higher') }}-->
+            <!--                      </span>-->
+            <!--                      <span v-if="item.badge.code === 2">-->
+            <!--                        {{ $t('levels.reliableEmp') }}-->
+            <!--                      </span>-->
+            <!--                      <span v-if="item.badge.code === 3">-->
+            <!--                        {{ $t('levels.checkedByTime') }}-->
+            <!--                      </span>-->
+            <!--                    </div>-->
+          </div>
+        </div>
+      </div>
     </div>
-    <span v-if="!filteredResponses.length">
-      <div class="info__message">{{ $t('quests.employer.usersNotResponded') }}</div>
-    </span>
   </div>
 </template>
 
@@ -91,6 +94,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.info {
+  &__message {
+    @include text-simple;
+    margin: 0 0 15px 0;
+    font-size: 16px;
+    color: $black400;
+  }
+}
 .row {
   display: flex;
   flex-direction: row;

--- a/components/app/pages/quests_id/respondedWorkerList.vue
+++ b/components/app/pages/quests_id/respondedWorkerList.vue
@@ -1,74 +1,69 @@
 <template>
-  <div>
+  <div
+    v-if="currentWorker"
+    class="worker worker__card"
+  >
     <div
-      v-if="currentWorker"
-      class="worker worker__card"
+      class="worker__title"
     >
+      {{ $t('response.title') }}
+    </div>
+    <div class="worker__container">
       <div
-        class="worker__title"
+        v-if="filteredResponses.length === 0"
+        class="info__message"
       >
-        {{ $t('response.title') }}
+        {{ $t('quests.employer.usersNotResponded') }}
       </div>
-      <div class="worker__container">
+      <div
+        v-for="(response, i) in filteredResponses"
+        :key="i"
+        class="worker worker__col_two"
+      >
         <div
-          v-if="filteredResponses.length === 0"
-          class="info__message"
+          v-if="response.worker.firstName && response.worker.lastName"
+          class="worker row"
         >
-          {{ $t('quests.employer.usersNotResponded') }}
-        </div>
-        <div
-          v-for="(response, i) in filteredResponses"
-          :key="i"
-        >
-          <div
-            class="worker worker__col_two"
+          <img
+            class="worker__avatar"
+            :src="response.worker.avatar ? response.worker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
+            alt=""
           >
-            <div
-              v-if="response.worker.firstName && response.worker.lastName"
-              class="worker row"
-            >
-              <img
-                class="worker__avatar"
-                :src="response.worker.avatar ? response.worker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
-                alt=""
-              >
-              <div
-                class="worker__name"
-              >
-                {{ response.worker.firstName }} {{ response.worker.lastName }}
-              </div>
-            </div>
-            <quest-id-dd
-              :i="i"
-              :response-id="response.id"
-            />
-            <div class="worker__message">
-              {{ response.message }}
-            </div>
-          </div>
-          <div>
-            <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка-->
-            <!--                    <div-->
-            <!--                      v-if="item.badge.code !== 0"-->
-            <!--                      class="card__level_higher"-->
-            <!--                      :class="[-->
-            <!--                        {'card__level_higher': item.badge.code === 1},-->
-            <!--                        {'card__level_reliable': item.badge.code === 2},-->
-            <!--                        {'card__level_checked': item.badge.code === 3}-->
-            <!--                      ]"-->
-            <!--                    >-->
-            <!--                      <span v-if="item.badge.code === 1">-->
-            <!--                        {{ $t('levels.higher') }}-->
-            <!--                      </span>-->
-            <!--                      <span v-if="item.badge.code === 2">-->
-            <!--                        {{ $t('levels.reliableEmp') }}-->
-            <!--                      </span>-->
-            <!--                      <span v-if="item.badge.code === 3">-->
-            <!--                        {{ $t('levels.checkedByTime') }}-->
-            <!--                      </span>-->
-            <!--                    </div>-->
+          <div
+            class="worker__name"
+          >
+            {{ response.worker.firstName }} {{ response.worker.lastName }}
           </div>
         </div>
+        <quest-id-dd
+          :i="i"
+          :response-id="response.id"
+        />
+        <div class="worker__message">
+          {{ response.message }}
+        </div>
+      </div>
+      <div>
+        <!--                      TODO: НАСТРОИТЬ ВЫВОД СТАТУСА нет бэка-->
+        <!--                    <div-->
+        <!--                      v-if="item.badge.code !== 0"-->
+        <!--                      class="card__level_higher"-->
+        <!--                      :class="[-->
+        <!--                        {'card__level_higher': item.badge.code === 1},-->
+        <!--                        {'card__level_reliable': item.badge.code === 2},-->
+        <!--                        {'card__level_checked': item.badge.code === 3}-->
+        <!--                      ]"-->
+        <!--                    >-->
+        <!--                      <span v-if="item.badge.code === 1">-->
+        <!--                        {{ $t('levels.higher') }}-->
+        <!--                      </span>-->
+        <!--                      <span v-if="item.badge.code === 2">-->
+        <!--                        {{ $t('levels.reliableEmp') }}-->
+        <!--                      </span>-->
+        <!--                      <span v-if="item.badge.code === 3">-->
+        <!--                        {{ $t('levels.checkedByTime') }}-->
+        <!--                      </span>-->
+        <!--                    </div>-->
       </div>
     </div>
   </div>

--- a/components/app/pages/quests_id/respondedWorkerList.vue
+++ b/components/app/pages/quests_id/respondedWorkerList.vue
@@ -1,13 +1,15 @@
 <template>
   <div>
-    <div class="worker worker__card">
+    <div
+      v-if="currentWorker"
+      class="worker worker__card"
+    >
       <div
-        v-if="currentWorker"
         class="worker__title"
       >
         {{ $t('response.title') }}
       </div>
-      <span v-if="filteredResponses.length">
+      <span v-if="filteredResponses.length > 0">
         <span
           v-for="(response, i) in filteredResponses"
           :key="i"

--- a/components/app/pages/quests_id/starRating.vue
+++ b/components/app/pages/quests_id/starRating.vue
@@ -2,14 +2,12 @@
   <!--                    TODO: Исправить код оценки квеста-->
   <div
     class="rating-area"
-    @click="setRating()"
   >
     <input
       id="star-5"
-      v-model="starRating"
       type="radio"
       name="rating"
-      value="5"
+      @click="setRating(5)"
     >
     <label
       for="star-5"
@@ -17,10 +15,9 @@
     />
     <input
       id="star-4"
-      v-model="starRating"
       type="radio"
       name="rating"
-      value="4"
+      @click="setRating(4)"
     >
     <label
       for="star-4"
@@ -28,10 +25,9 @@
     />
     <input
       id="star-3"
-      v-model="starRating"
       type="radio"
       name="rating"
-      value="3"
+      @click="setRating(3)"
     >
     <label
       for="star-3"
@@ -39,10 +35,9 @@
     />
     <input
       id="star-2"
-      v-model="starRating"
       type="radio"
       name="rating"
-      value="2"
+      @click="setRating(2)"
     >
     <label
       for="star-2"
@@ -50,10 +45,9 @@
     />
     <input
       id="star-1"
-      v-model="starRating"
       type="radio"
       name="rating"
-      value="1"
+      @click="setRating(1)"
     >
     <label
       for="star-1"
@@ -76,8 +70,8 @@ export default {
     };
   },
   methods: {
-    setRating() {
-      console.log(this.starRating);
+    setRating(n) {
+      console.log(n);
     },
   },
 };

--- a/components/app/pages/quests_id/starRating.vue
+++ b/components/app/pages/quests_id/starRating.vue
@@ -1,5 +1,5 @@
 <template>
-  <!--                    TODO: Исправить код оценки квеста-->
+  <!--  TODO: Вывести данные из компонента в модалку-->
   <div
     class="rating-area"
   >
@@ -63,11 +63,6 @@ export default {
       type: Object,
       default: () => {},
     },
-  },
-  data() {
-    return {
-      starRating: '',
-    };
   },
   methods: {
     setRating(n) {

--- a/components/app/pages/quests_id/starRating.vue
+++ b/components/app/pages/quests_id/starRating.vue
@@ -1,5 +1,4 @@
 <template>
-  <!--  TODO: Вывести данные из компонента в модалку-->
   <div
     class="rating-area"
   >

--- a/components/app/pages/quests_id/starRating.vue
+++ b/components/app/pages/quests_id/starRating.vue
@@ -66,7 +66,7 @@ export default {
   },
   methods: {
     setRating(n) {
-      console.log(n);
+      localStorage.setItem('questRating', n);
     },
   },
 };

--- a/components/app/pages/quests_id/starRating.vue
+++ b/components/app/pages/quests_id/starRating.vue
@@ -1,0 +1,125 @@
+<template>
+  <!--                    TODO: Исправить код оценки квеста-->
+  <div
+    class="rating-area"
+    @click="setRating()"
+  >
+    <input
+      id="star-5"
+      v-model="starRating"
+      type="radio"
+      name="rating"
+      value="5"
+    >
+    <label
+      for="star-5"
+      title="Оценка «5»"
+    />
+    <input
+      id="star-4"
+      v-model="starRating"
+      type="radio"
+      name="rating"
+      value="4"
+    >
+    <label
+      for="star-4"
+      title="Оценка «4»"
+    />
+    <input
+      id="star-3"
+      v-model="starRating"
+      type="radio"
+      name="rating"
+      value="3"
+    >
+    <label
+      for="star-3"
+      title="Оценка «3»"
+    />
+    <input
+      id="star-2"
+      v-model="starRating"
+      type="radio"
+      name="rating"
+      value="2"
+    >
+    <label
+      for="star-2"
+      title="Оценка «2»"
+    />
+    <input
+      id="star-1"
+      v-model="starRating"
+      type="radio"
+      name="rating"
+      value="1"
+    >
+    <label
+      for="star-1"
+      title="Оценка «1»"
+    />
+  </div>
+</template>
+<script>
+export default {
+  name: 'StarRating',
+  props: {
+    rating: {
+      type: Object,
+      default: () => {},
+    },
+  },
+  data() {
+    return {
+      starRating: '',
+    };
+  },
+  methods: {
+    setRating() {
+      console.log(this.starRating);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.rating-area {
+  overflow: hidden;
+  width: 265px;
+  margin: 0 auto;
+}
+.rating-area:not(:checked) > input {
+  display: none;
+}
+.rating-area:not(:checked) > label {
+  float: right;
+  padding: 0;
+  cursor: pointer;
+  font-size: 25px;
+  line-height: 25px;
+  color: lightgrey;
+  text-shadow: 1px 1px #bbb;
+}
+.rating-area:not(:checked) > label:before {
+  content: '★';
+}
+.rating-area > input:checked ~ label {
+  color: gold;
+}
+.rating-area:not(:checked) > label:hover,
+.rating-area:not(:checked) > label:hover ~ label {
+  color: gold;
+}
+.rating-area > input:checked + label:hover,
+.rating-area > input:checked + label:hover ~ label,
+.rating-area > input:checked ~ label:hover,
+.rating-area > input:checked ~ label:hover ~ label,
+.rating-area > label:hover ~ input:checked ~ label {
+  color: gold;
+  text-shadow: 1px 1px goldenrod;
+}
+.rate-area > label:active {
+  position: relative;
+}
+</style>

--- a/components/app/pages/quests_id/worker.vue
+++ b/components/app/pages/quests_id/worker.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="['worker'].includes(userRole)"
+    v-if="userRole === 'worker'"
     :class="[
       {'btns__container': [1,2,3,5,7].includes(infoDataMode)},
       {'btns__margin': ![1,2,3,5,7].includes(infoDataMode)}

--- a/components/app/pages/quests_id/worker.vue
+++ b/components/app/pages/quests_id/worker.vue
@@ -119,7 +119,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import modals from '~/store/modals/modals';
-import { InfoModeW, QStatuses } from '~/utils/enums';
+import { InfoModeWorker, QuestStatuses } from '~/utils/enums';
 
 export default {
   name: 'QuestIdWorker',
@@ -138,13 +138,13 @@ export default {
       infoDataMode: 'quests/getInfoDataMode',
     }),
     QuestStatuses() {
-      return QStatuses;
+      return QuestStatuses;
     },
     InfoModeWorker() {
-      return InfoModeW;
+      return InfoModeWorker;
     },
     disabledBtn() {
-      return this.infoDataMode === InfoModeW.Rejected;
+      return this.infoDataMode === InfoModeWorker.Rejected;
     },
   },
   async created() {
@@ -191,7 +191,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.workOnQuestAccepted'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', InfoModeW.Active);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeWorker.Active);
       this.SetLoader(false);
     },
     async rejectWorkOnQuest() {
@@ -203,7 +203,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.workOnQuestRejected'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', InfoModeW.Created);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeWorker.Created);
       this.SetLoader(false);
     },
     async completeWorkOnQuest() {
@@ -215,7 +215,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.pleaseWaitEmp'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', InfoModeW.WaitConfirm);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeWorker.WaitConfirm);
       this.SetLoader(false);
     },
     // async getResponseId() {

--- a/components/app/pages/quests_id/worker.vue
+++ b/components/app/pages/quests_id/worker.vue
@@ -2,12 +2,13 @@
   <div
     v-if="userRole === 'worker'"
     :class="[
-      {'btns__container': [1,2,3,5,7].includes(infoDataMode)},
-      {'btns__margin': ![1,2,3,5,7].includes(infoDataMode)}
+      {'btns__container':
+        ![InfoModeWorker.WaitConfirm, InfoModeWorker.Closed, InfoModeWorker.Done].includes(infoDataMode)},
+      {'btns__margin': [InfoModeWorker.WaitConfirm, InfoModeWorker.Closed, InfoModeWorker.Done].includes(infoDataMode)}
     ]"
   >
     <div
-      v-if="[1].includes(infoDataMode)"
+      v-if="infoDataMode === InfoModeWorker.ADChat"
       class="btns__wrapper"
     >
       <div class="btn__wrapper">
@@ -38,7 +39,7 @@
       </div>
     </div>
     <div
-      v-if="[2].includes(infoDataMode)"
+      v-if="infoDataMode === InfoModeWorker.Active"
       class="btns__wrapper"
     >
       <div class="btn__wrapper">
@@ -69,44 +70,31 @@
       </div>
     </div>
     <div
-      v-if="[3].includes(infoDataMode)"
+      v-if="[InfoModeWorker.Rejected, InfoModeWorker.Created].includes(infoDataMode)"
       class="btns__wrapper"
     >
       <div class="btn__wrapper">
         <base-btn
-          :disabled="true"
+          :disabled="disabledBtn"
           @click="sendARequestOnQuest"
         >
-          {{ $t('btn.responded') }}
+          {{ InfoModeWorker.Created ? $t('btn.sendARequest') : $t('btn.responded') }}
         </base-btn>
       </div>
     </div>
     <div
-      v-if="[5].includes(infoDataMode)"
+      v-if="infoDataMode === InfoModeWorker.Dispute"
       class="btns__wrapper"
     >
       <div class="btn__wrapper">
-        <base-btn
-          :disabled="questData.status === -1"
-          @click="sendARequestOnQuest"
-        >
-          {{ $t('btn.sendARequest') }}
-        </base-btn>
-      </div>
-    </div>
-    <div
-      v-if="[7].includes(infoDataMode)"
-      class="btns__wrapper"
-    >
-      <div class="btn__wrapper">
-        <base-btn :disabled="true">
+        <base-btn>
           {{ $t('btn.dispute') }}
         </base-btn>
       </div>
     </div>
     <div class="priority">
       <div
-        v-if="![4,8].includes(infoDataMode)"
+        v-if="![InfoModeWorker.WaitConfirm, InfoModeWorker.Closed].includes(infoDataMode)"
         class="price__container"
       >
         <span class="price__value">
@@ -117,7 +105,7 @@
         class="priority__container"
       >
         <div
-          v-if="![4,8].includes(infoDataMode)"
+          v-if="![InfoModeWorker.WaitConfirm, InfoModeWorker.Closed].includes(infoDataMode)"
           class="priority__title"
           :class="getPriorityClass(questData.priority)"
         >
@@ -131,6 +119,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import modals from '~/store/modals/modals';
+import { InfoModeW, QStatuses } from '~/utils/enums';
 
 export default {
   name: 'QuestIdWorker',
@@ -148,6 +137,15 @@ export default {
       questData: 'quests/getQuest',
       infoDataMode: 'quests/getInfoDataMode',
     }),
+    QuestStatuses() {
+      return QStatuses;
+    },
+    InfoModeWorker() {
+      return InfoModeW;
+    },
+    disabledBtn() {
+      return this.infoDataMode === InfoModeW.Rejected;
+    },
   },
   async created() {
     await this.getResponsesToQuestForAuthUser();
@@ -193,7 +191,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.workOnQuestAccepted'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', 2);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeW.Active);
       this.SetLoader(false);
     },
     async rejectWorkOnQuest() {
@@ -205,7 +203,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.workOnQuestRejected'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', 5);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeW.Created);
       this.SetLoader(false);
     },
     async completeWorkOnQuest() {
@@ -217,7 +215,7 @@ export default {
         title: this.$t('quests.questInfo'),
         subtitle: this.$t('quests.pleaseWaitEmp'),
       });
-      await this.$store.dispatch('quests/setInfoDataMode', 4);
+      await this.$store.dispatch('quests/setInfoDataMode', InfoModeW.WaitConfirm);
       this.SetLoader(false);
     },
     // async getResponseId() {

--- a/components/app/panels/questPanel.vue
+++ b/components/app/panels/questPanel.vue
@@ -85,7 +85,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import moment from 'moment';
-import { InfoModeE, InfoModeW } from '~/utils/enums';
+import { InfoModeEmployer, InfoModeWorker } from '~/utils/enums';
 import modals from '~/store/modals/modals';
 
 export default {
@@ -127,10 +127,10 @@ export default {
       infoDataMode: 'quests/getInfoDataMode',
     }),
     InfoModeEmployer() {
-      return InfoModeE;
+      return InfoModeEmployer;
     },
     InfoModeWorker() {
-      return InfoModeW;
+      return InfoModeWorker;
     },
   },
   async mounted() {

--- a/components/app/panels/questPanel.vue
+++ b/components/app/panels/questPanel.vue
@@ -35,7 +35,8 @@
             </span>
             <quest-dd
               v-if="userRole === 'employer'
-                ? ![8, 9].includes(infoDataMode) : ![4, 9].includes(infoDataMode)"
+                ? ![InfoModeEmployer.Closed, InfoModeEmployer.Done].includes(infoDataMode)
+                : ![InfoModeWorker.WaitConfirm, InfoModeWorker.Done].includes(infoDataMode)"
             />
           </div>
         </div>
@@ -84,6 +85,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import moment from 'moment';
+import { InfoModeE, InfoModeW } from '~/utils/enums';
 import modals from '~/store/modals/modals';
 
 export default {
@@ -124,6 +126,12 @@ export default {
       userCompany: 'quests/getQuestUserCompany',
       infoDataMode: 'quests/getInfoDataMode',
     }),
+    InfoModeEmployer() {
+      return InfoModeE;
+    },
+    InfoModeWorker() {
+      return InfoModeW;
+    },
   },
   async mounted() {
     this.SetLoader(true);

--- a/components/ui/QuestIdDD/index.vue
+++ b/components/ui/QuestIdDD/index.vue
@@ -220,6 +220,7 @@ export default {
     min-height: 20px;
     width: 100%;
     border-bottom: 1px solid $black100;
+    cursor: pointer;
   }
   &__text {
     font-family: 'Inter', sans-serif;

--- a/locales/en.json
+++ b/locales/en.json
@@ -269,6 +269,7 @@
     "questClosed!": "Quest closed!",
     "closed": "Closed",
     "completed": "Completed",
+    "rejected": "Rejected",
     "completedWorkAccepted": "Completed work on quest accepted!",
     "completedWorkRejected": "Completed work on quest rejected!",
     "workOnQuestAccepted": "Work on quest accepted!",

--- a/locales/en.json
+++ b/locales/en.json
@@ -259,6 +259,7 @@
     "employer": {
       "usersNotResponded": "Users have not yet responded to the quest"
     },
+    "workersNotInvited": "Workers not invited!",
     "startChat": "Start chat",
     "invite": "Invite",
     "decline": "Decline",

--- a/pages/quests/_id/index.vue
+++ b/pages/quests/_id/index.vue
@@ -270,13 +270,13 @@ export default {
           && questStatus === QuestStatuses.Created: payload = InfoModeEmployer.RaiseViews; break;
           case responsesCount > 0
           && questStatus === QuestStatuses.Created: payload = InfoModeEmployer.Created; break;
-          case assignedWorker !== {}
+          case Object.keys(assignedWorker).length > 0
           && ![QuestStatuses.Closed, QuestStatuses.Dispute, QuestStatuses.WaitConfirm, QuestStatuses.Done].includes(questStatus):
             payload = InfoModeEmployer.WaitWorker; break;
           case questStatus === QuestStatuses.Active: payload = InfoModeEmployer.Active; break;
           case questStatus === QuestStatuses.Closed: payload = InfoModeEmployer.Closed; break;
           case questStatus === QuestStatuses.Dispute: payload = InfoModeEmployer.Dispute; break;
-          case questStatus === QuestStatuses.WaitConfirm && assignedWorker !== {}: payload = InfoModeEmployer.WaitConfirm; break;
+          case questStatus === QuestStatuses.WaitConfirm && Object.keys(assignedWorker).length > 0: payload = InfoModeEmployer.WaitConfirm; break;
           case questStatus === QuestStatuses.Done && responsesCount > 0: payload = InfoModeEmployer.Done; break;
           default: { payload = InfoModeEmployer.RaiseViews; break; }
         }

--- a/pages/quests/_id/index.vue
+++ b/pages/quests/_id/index.vue
@@ -37,7 +37,7 @@
         </div>
         <div
           v-if="userRole === 'employer'
-            ? [2, 8, 9].includes(infoDataMode) : [1, 2, 3, 4, 9].includes(infoDataMode)"
+            ? [2, 8, 9].includes(infoDataMode) : [1, 2, 3, 5, 4, 9].includes(infoDataMode)"
           class="divider"
         />
         <questIdEmployer

--- a/pages/quests/_id/index.vue
+++ b/pages/quests/_id/index.vue
@@ -132,7 +132,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import {
-  QStatuses, InfoModeW, InfoModeE, responsesType,
+  QuestStatuses, InfoModeWorker, InfoModeEmployer, responsesType,
 } from '~/utils/enums';
 import modals from '~/store/modals/modals';
 import info from '~/components/app/info/index.vue';
@@ -201,10 +201,10 @@ export default {
       infoDataMode: 'quests/getInfoDataMode',
     }),
     InfoModeEmployer() {
-      return InfoModeE;
+      return InfoModeEmployer;
     },
     InfoModeWorker() {
-      return InfoModeW;
+      return InfoModeWorker;
     },
     priority() {
       return [
@@ -267,33 +267,33 @@ export default {
       if (userRole === 'employer') {
         switch (true) {
           case responsesCount === 0
-          && questStatus === QStatuses.Created: payload = InfoModeE.RaiseViews; break;
+          && questStatus === QuestStatuses.Created: payload = InfoModeEmployer.RaiseViews; break;
           case responsesCount > 0
-          && questStatus === QStatuses.Created: payload = InfoModeE.Created; break;
+          && questStatus === QuestStatuses.Created: payload = InfoModeEmployer.Created; break;
           case assignedWorker !== {}
-          && ![QStatuses.Closed, QStatuses.Dispute, QStatuses.WaitConfirm, QStatuses.Done].includes(questStatus):
-            payload = InfoModeE.WaitWorker; break;
-          case questStatus === QStatuses.Active: payload = InfoModeE.Active; break;
-          case questStatus === QStatuses.Closed: payload = InfoModeE.Closed; break;
-          case questStatus === QStatuses.Dispute: payload = InfoModeE.Dispute; break;
-          case questStatus === QStatuses.WaitConfirm && assignedWorker !== {}: payload = InfoModeE.WaitConfirm; break;
-          case questStatus === QStatuses.Done && responsesCount > 0: payload = InfoModeE.Done; break;
-          default: { payload = InfoModeE.RaiseViews; break; }
+          && ![QuestStatuses.Closed, QuestStatuses.Dispute, QuestStatuses.WaitConfirm, QuestStatuses.Done].includes(questStatus):
+            payload = InfoModeEmployer.WaitWorker; break;
+          case questStatus === QuestStatuses.Active: payload = InfoModeEmployer.Active; break;
+          case questStatus === QuestStatuses.Closed: payload = InfoModeEmployer.Closed; break;
+          case questStatus === QuestStatuses.Dispute: payload = InfoModeEmployer.Dispute; break;
+          case questStatus === QuestStatuses.WaitConfirm && assignedWorker !== {}: payload = InfoModeEmployer.WaitConfirm; break;
+          case questStatus === QuestStatuses.Done && responsesCount > 0: payload = InfoModeEmployer.Done; break;
+          default: { payload = InfoModeEmployer.RaiseViews; break; }
         }
         await this.$store.dispatch('quests/setInfoDataMode', payload);
       }
       if (userRole === 'worker') {
         switch (true) {
-          case questStatus === QStatuses.Rejected: payload = InfoModeW.Rejected; break;
-          case questStatus === QStatuses.Created: payload = InfoModeW.Created; break;
-          case questStatus === QStatuses.Active: payload = InfoModeW.Active; break;
-          case questStatus === QStatuses.Closed: payload = InfoModeW.Closed; break;
-          case questStatus === QStatuses.Dispute: payload = InfoModeW.Dispute; break;
-          case questStatus === QStatuses.WaitConfirm: payload = InfoModeW.WaitConfirm; break;
-          case questStatus === QStatuses.Done: payload = InfoModeW.Done; break;
+          case questStatus === QuestStatuses.Rejected: payload = InfoModeWorker.Rejected; break;
+          case questStatus === QuestStatuses.Created: payload = InfoModeWorker.Created; break;
+          case questStatus === QuestStatuses.Active: payload = InfoModeWorker.Active; break;
+          case questStatus === QuestStatuses.Closed: payload = InfoModeWorker.Closed; break;
+          case questStatus === QuestStatuses.Dispute: payload = InfoModeWorker.Dispute; break;
+          case questStatus === QuestStatuses.WaitConfirm: payload = InfoModeWorker.WaitConfirm; break;
+          case questStatus === QuestStatuses.Done: payload = InfoModeWorker.Done; break;
           case assignedWorkerId === userId
-          && ![InfoModeW.Active, InfoModeW.Dispute].includes(questStatus): payload = InfoModeW.ADChat; break;
-          default: { payload = InfoModeW.ADChat; break; }
+          && ![InfoModeWorker.Active, InfoModeWorker.Dispute].includes(questStatus): payload = InfoModeWorker.ADChat; break;
+          default: { payload = InfoModeWorker.ADChat; break; }
         }
         await this.$store.dispatch('quests/setInfoDataMode', payload);
       }

--- a/pages/quests/_id/index.vue
+++ b/pages/quests/_id/index.vue
@@ -245,8 +245,6 @@ export default {
       if (this.userRole === 'employer') {
         this.filteredResponses = this.responsesToQuest.filter((response) => response.status === 0 && response.type === responsesType.Responded);
         this.filteredInvited = this.responsesToQuest.filter((response) => response.status === 0 && response.type === responsesType.Invited);
-        console.log('filteredResponses', this.filteredResponses);
-        console.log('filteredInvited', this.filteredInvited);
         return this.filteredResponses && this.filteredInvited;
       }
       return '';

--- a/pages/quests/_id/index.vue
+++ b/pages/quests/_id/index.vue
@@ -53,7 +53,7 @@
     <div class="main">
       <div class="main__body">
         <div v-if="userRole === 'employer'">
-          <div v-if="infoDataMode === InfoModeEmployer.Active">
+          <div v-if="infoDataMode === InfoModeEmployer.Created">
             <invited-worker-list :current-worker="currentWorker" />
             <responded-worker-list
               :current-worker="currentWorker"

--- a/pages/quests/_id/index.vue
+++ b/pages/quests/_id/index.vue
@@ -54,7 +54,10 @@
       <div class="main__body">
         <div v-if="userRole === 'employer'">
           <div v-if="infoDataMode === InfoModeEmployer.Created">
-            <invited-worker-list :current-worker="currentWorker" />
+            <invited-worker-list
+              :current-worker="currentWorker"
+              :filtered-invited="filteredInvited"
+            />
             <responded-worker-list
               :current-worker="currentWorker"
               :filtered-responses="filteredResponses"
@@ -128,7 +131,9 @@
 </template>
 <script>
 import { mapGetters } from 'vuex';
-import { QStatuses, InfoModeW, InfoModeE } from '~/utils/enums';
+import {
+  QStatuses, InfoModeW, InfoModeE, responsesType,
+} from '~/utils/enums';
 import modals from '~/store/modals/modals';
 import info from '~/components/app/info/index.vue';
 import questPanel from '~/components/app/panels/questPanel';
@@ -156,6 +161,7 @@ export default {
         spec: 'Painting works',
       },
       filteredResponses: [],
+      filteredInvited: [],
       isShowMap: true,
       priorityIndex: 0,
       distanceIndex: 0,
@@ -237,8 +243,11 @@ export default {
     },
     async getFilteredResponses() {
       if (this.userRole === 'employer') {
-        this.filteredResponses = this.responsesToQuest.filter((response) => response.status === 0);
-        return this.filteredResponses;
+        this.filteredResponses = this.responsesToQuest.filter((response) => response.status === 0 && response.type === responsesType.Responded);
+        this.filteredInvited = this.responsesToQuest.filter((response) => response.status === 0 && response.type === responsesType.Invited);
+        console.log('filteredResponses', this.filteredResponses);
+        console.log('filteredInvited', this.filteredInvited);
+        return this.filteredResponses && this.filteredInvited;
       }
       return '';
     },

--- a/pages/workers/_id/index.vue
+++ b/pages/workers/_id/index.vue
@@ -893,6 +893,7 @@ export default {
   @extend .styles__flex;
   padding: 25px 0;
   position: relative;
+  display: grid;
   .share-btn {
     height: 24px;
     width: 24px;
@@ -1251,7 +1252,6 @@ a:hover {
 @include _1199 {
   .contact {
     display: flex;
-    flex-direction: column;
   }
   .template {
     &__main {

--- a/pages/workers/_id/index.vue
+++ b/pages/workers/_id/index.vue
@@ -32,9 +32,10 @@
                   </span>
                 </div>
                 <div
+                  v-if="currentWorker"
                   class="description"
                 >
-                  <!--                  {{ currentWorker ? currentWorker.additionalInfo.description: $t('quests.nothingAboutMe') }}-->
+                  {{ currentWorker ? currentWorkerAddInfo.description: $t('quests.nothingAboutMe') }}
                 </div>
                 <social />
                 <div class="contacts__grid">
@@ -48,19 +49,19 @@
                             class="icon-location"
                           />
                           <span class="contact__link">
-                            <!--                            {{ currentWorker ? currentWorker.additionalInfo.address : $t('quests.unknownAddress') }}-->
+                            {{ currentWorker ? currentWorkerAddInfo.address : $t('quests.unknownAddress') }}
                           </span>
                         </span>
                         <span class="contact__container">
                           <span class="icon-phone" />
                           <span class="contact__link">
-                            <!--                            {{ currentWorker ? currentWorker.additionalInfo.phone : $t('quests.unknownPhoneNumber') }}-->
+                            {{ currentWorker ? currentWorkerAddInfo.phone : $t('quests.unknownPhoneNumber') }}
                           </span>
                         </span>
                         <span class="contact__container">
                           <span class="icon-mail" />
                           <span class="contact__link">
-                            {{ currentWorker ? currentWorker.additionalInfo.email : $t('quests.unknownEmailAddress') }}
+                            {{ currentWorker ? currentWorkerAddInfo.email : $t('quests.unknownEmailAddress') }}
                           </span>
                         </span>
                       </span>
@@ -181,15 +182,14 @@ export default {
       user: 'data/getUserInfo',
       workersList: 'quests/getWorkersList',
       currentWorker: 'quests/getCurrentWorker',
+      currentWorkerAddInfo: 'quests/getCurrentWorkerAddInfo',
     }),
   },
   async created() {
-    await this.initWorkers();
     await this.initWorker();
   },
   async mounted() {
     this.SetLoader(true);
-    // await this.initWorker();
     this.SetLoader(false);
   },
   methods: {
@@ -203,19 +203,13 @@ export default {
       await this.$store.dispatch('quests/workersList');
     },
     async initWorker() {
-      // const userId = this.$route.params.id;
-      // try {
-      //   await this.$store.dispatch('quests/getWorkerData', userId);
-      //   console.log(this.currentWorker);
-      // } catch (e) {
-      //   console.log(e);
-      // }
-      const currentWorkerId = this.$route.path.slice(-36);
-      const workersList = this.workersList.users;
-      const filteredWorker = workersList.filter((worker) => worker.id === currentWorkerId);
-      const worker = filteredWorker[0];
-      console.log(worker);
-      await this.$store.dispatch('quests/setCurrentWorker', worker);
+      const userId = this.$route.params.id;
+      try {
+        await this.$store.dispatch('quests/getWorkerData', userId);
+        console.log(this.currentWorker);
+      } catch (e) {
+        console.log(e);
+      }
     },
   },
 };

--- a/pages/workers/_id/index.vue
+++ b/pages/workers/_id/index.vue
@@ -12,8 +12,8 @@
                   <img
                     v-if="Object.keys(currentWorker).length !== 0"
                     class="info-grid__avatar"
-                    :src="currentWorker ? currentWorker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
-                    alt=""
+                    :src="currentWorker.avatar !== null ? currentWorker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
+                    :alt="currentWorker.firstName"
                   >
                 </div>
                 <div class="rating" />
@@ -183,9 +183,13 @@ export default {
       currentWorker: 'quests/getCurrentWorker',
     }),
   },
+  async created() {
+    await this.initWorkers();
+    await this.initWorker();
+  },
   async mounted() {
     this.SetLoader(true);
-    await this.initWorker();
+    // await this.initWorker();
     this.SetLoader(false);
   },
   methods: {
@@ -195,15 +199,23 @@ export default {
         currentWorker: this.currentWorker,
       });
     },
+    async initWorkers() {
+      await this.$store.dispatch('quests/workersList');
+    },
     async initWorker() {
-      console.log(1);
-      const userId = this.$route.params.id;
-      try {
-        await this.$store.dispatch('quests/getWorkerData', userId);
-        console.log(this.currentWorker);
-      } catch (e) {
-        console.log(e);
-      }
+      // const userId = this.$route.params.id;
+      // try {
+      //   await this.$store.dispatch('quests/getWorkerData', userId);
+      //   console.log(this.currentWorker);
+      // } catch (e) {
+      //   console.log(e);
+      // }
+      const currentWorkerId = this.$route.path.slice(-36);
+      const workersList = this.workersList.users;
+      const filteredWorker = workersList.filter((worker) => worker.id === currentWorkerId);
+      const worker = filteredWorker[0];
+      console.log(worker);
+      await this.$store.dispatch('quests/setCurrentWorker', worker);
     },
   },
 };

--- a/pages/workers/_id/index.vue
+++ b/pages/workers/_id/index.vue
@@ -12,7 +12,8 @@
                   <img
                     v-if="Object.keys(currentWorker).length !== 0"
                     class="info-grid__avatar"
-                    :src="currentWorker.avatar !== null ? currentWorker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
+                    :src="currentWorker.avatar !== null
+                      ? currentWorker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
                     :alt="currentWorker.firstName"
                   >
                 </div>
@@ -26,7 +27,8 @@
               </div>
               <div class="col info-grid__col">
                 <div class="title title_inline">
-                  {{ currentWorker ? currentWorker.firstName : 'Nameless' }} {{ currentWorker ? currentWorker.lastName : "" }}
+                  {{ currentWorker.firstName !== null ? currentWorker.firstName : 'Nameless' }}
+                  {{ currentWorker.lastName !== null ? currentWorker.lastName : "" }}
                   <span class="level">
                     TOP RANKED EMP.
                   </span>
@@ -35,7 +37,8 @@
                   v-if="currentWorker"
                   class="description"
                 >
-                  {{ currentWorker ? currentWorkerAddInfo.description: $t('quests.nothingAboutMe') }}
+                  {{ currentWorkerAddInfo.description !== null
+                    ? currentWorkerAddInfo.description: $t('quests.nothingAboutMe') }}
                 </div>
                 <social />
                 <div class="contacts__grid">
@@ -49,19 +52,22 @@
                             class="icon-location"
                           />
                           <span class="contact__link">
-                            {{ currentWorker ? currentWorkerAddInfo.address : $t('quests.unknownAddress') }}
+                            {{ currentWorkerAddInfo.address !== null
+                              ? currentWorkerAddInfo.address : $t('quests.unknownAddress') }}
                           </span>
                         </span>
                         <span class="contact__container">
                           <span class="icon-phone" />
                           <span class="contact__link">
-                            {{ currentWorker ? currentWorkerAddInfo.phone : $t('quests.unknownPhoneNumber') }}
+                            {{ currentWorker.phone !== null
+                              ? currentWorker.phone : $t('quests.unknownPhoneNumber') }}
                           </span>
                         </span>
                         <span class="contact__container">
                           <span class="icon-mail" />
                           <span class="contact__link">
-                            {{ currentWorker ? currentWorkerAddInfo.email : $t('quests.unknownEmailAddress') }}
+                            {{ currentWorker.email !== null
+                              ? currentWorker.email : $t('quests.unknownEmailAddress') }}
                           </span>
                         </span>
                       </span>
@@ -206,7 +212,8 @@ export default {
       const userId = this.$route.params.id;
       try {
         await this.$store.dispatch('quests/getWorkerData', userId);
-        console.log(this.currentWorker);
+        console.log('currentWorkerAddInfo', this.currentWorkerAddInfo);
+        console.log('currentWorker', this.currentWorker);
       } catch (e) {
         console.log(e);
       }

--- a/pages/workers/_id/index.vue
+++ b/pages/workers/_id/index.vue
@@ -212,8 +212,6 @@ export default {
       const userId = this.$route.params.id;
       try {
         await this.$store.dispatch('quests/getWorkerData', userId);
-        console.log('currentWorkerAddInfo', this.currentWorkerAddInfo);
-        console.log('currentWorker', this.currentWorker);
       } catch (e) {
         console.log(e);
       }

--- a/pages/workers/_id/index.vue
+++ b/pages/workers/_id/index.vue
@@ -12,8 +12,8 @@
                   <img
                     v-if="Object.keys(currentWorker).length !== 0"
                     class="info-grid__avatar"
-                    :src="currentWorker.avatar !== null ? currentWorker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
-                    :alt="currentWorker.firstName"
+                    :src="currentWorker ? currentWorker.avatar.url: require('~/assets/img/app/avatar_empty.png')"
+                    alt=""
                   >
                 </div>
                 <div class="rating" />
@@ -26,7 +26,7 @@
               </div>
               <div class="col info-grid__col">
                 <div class="title title_inline">
-                  {{ currentWorker.firstName ? currentWorker.firstName : 'Nameless' }} {{ currentWorker.lastName ? currentWorker.lastName : "" }}
+                  {{ currentWorker ? currentWorker.firstName : 'Nameless' }} {{ currentWorker ? currentWorker.lastName : "" }}
                   <span class="level">
                     TOP RANKED EMP.
                   </span>
@@ -34,7 +34,7 @@
                 <div
                   class="description"
                 >
-                  {{ currentWorker ? currentWorker.additionalInfo.description: $t('quests.nothingAboutMe') }}
+                  <!--                  {{ currentWorker ? currentWorker.additionalInfo.description: $t('quests.nothingAboutMe') }}-->
                 </div>
                 <social />
                 <div class="contacts__grid">
@@ -48,13 +48,13 @@
                             class="icon-location"
                           />
                           <span class="contact__link">
-                            {{ currentWorker ? currentWorker.additionalInfo.address : $t('quests.unknownAddress') }}
+                            <!--                            {{ currentWorker ? currentWorker.additionalInfo.address : $t('quests.unknownAddress') }}-->
                           </span>
                         </span>
                         <span class="contact__container">
                           <span class="icon-phone" />
                           <span class="contact__link">
-                            {{ currentWorker ? currentWorker.additionalInfo.phone : $t('quests.unknownPhoneNumber') }}
+                            <!--                            {{ currentWorker ? currentWorker.additionalInfo.phone : $t('quests.unknownPhoneNumber') }}-->
                           </span>
                         </span>
                         <span class="contact__container">
@@ -88,7 +88,6 @@
             {{ $t('workers.skills') }}
           </div>
           <div>
-            <!-- TODO: Проверить механизм добавления скилов -->
             <span class="badge_blue">{{ $t('quests.skillsNotSpecified') }}</span>
           </div>
         </div>
@@ -184,12 +183,9 @@ export default {
       currentWorker: 'quests/getCurrentWorker',
     }),
   },
-  async created() {
-    await this.initWorkers();
-    await this.initWorker();
-  },
   async mounted() {
     this.SetLoader(true);
+    await this.initWorker();
     this.SetLoader(false);
   },
   methods: {
@@ -199,15 +195,15 @@ export default {
         currentWorker: this.currentWorker,
       });
     },
-    async initWorkers() {
-      await this.$store.dispatch('quests/workersList');
-    },
     async initWorker() {
-      // TODO: Исправить скрипт!
-      const currentWorkerId = this.$route.path.slice(-36);
-      const workersList = this.workersList.users;
-      const filteredWorker = workersList.filter((worker) => worker.id === currentWorkerId);
-      return await this.$store.dispatch('quests/setCurrentWorker', filteredWorker[0]);
+      console.log(1);
+      const userId = this.$route.params.id;
+      try {
+        await this.$store.dispatch('quests/getWorkerData', userId);
+        console.log(this.currentWorker);
+      } catch (e) {
+        console.log(e);
+      }
     },
   },
 };

--- a/pages/workers/_id/index.vue
+++ b/pages/workers/_id/index.vue
@@ -26,7 +26,7 @@
               </div>
               <div class="col info-grid__col">
                 <div class="title title_inline">
-                  {{ currentWorker.firstName }} {{ currentWorker.lastName }}
+                  {{ currentWorker.firstName ? currentWorker.firstName : 'Nameless' }} {{ currentWorker.lastName ? currentWorker.lastName : "" }}
                   <span class="level">
                     TOP RANKED EMP.
                   </span>

--- a/plugins/injectComponents.js
+++ b/plugins/injectComponents.js
@@ -20,6 +20,7 @@ import BaseTextarea from '~/components/ui/BaseTextarea';
 import QuestIdDD from '~/components/ui/QuestIdDD';
 import InvitedWorkerList from '~/components/app/pages/quests_id/invitedWorkerList';
 import RespondedWorkerList from '~/components/app/pages/quests_id/respondedWorkerList';
+import StarRating from '~/components/app/pages/quests_id/starRating';
 
 Vue.component('ctm-modal', CtmModal);
 Vue.component('ctm-modal-box', CtmModalBox);
@@ -41,3 +42,4 @@ Vue.component('base-textarea', BaseTextarea);
 Vue.component('vue-phone-number-input', VuePhoneNumberInput);
 Vue.component('invited-worker-list', InvitedWorkerList);
 Vue.component('responded-worker-list', RespondedWorkerList);
+Vue.component('star-rating', StarRating);

--- a/store/quests/actions.js
+++ b/store/quests/actions.js
@@ -1,4 +1,13 @@
 export default {
+  async getWorkerData({ commit }, userId) {
+    try {
+      const response = await this.$axios.$get(`/v1/profile/${userId}`);
+      commit('setCurrentWorker', response.result);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
+  },
   async questListForInvitation({ commit }, userId) {
     try {
       const response = await this.$axios.$get(`/v1/employer/${userId}/quests`);

--- a/store/quests/actions.js
+++ b/store/quests/actions.js
@@ -174,6 +174,8 @@ export default {
   async inviteOnQuest({ commit }, { questId, payload }) {
     try {
       const response = await this.$axios.$post(`/v1/quest/${questId}/invite`, payload);
+      const { chat } = response.result;
+      commit('setChatInviteOnQuest', chat);
       return response.result;
     } catch (e) {
       return console.log(e);

--- a/store/quests/getters.js
+++ b/store/quests/getters.js
@@ -3,6 +3,7 @@ export default {
   getQuestListForInvitation: (state) => state.questListForInvitation || {},
   getWorkersList: (state) => state.workersList,
   getCurrentWorker: (state) => state.currentWorker,
+  getCurrentWorkerAddInfo: (state) => state.currentWorker.additionalInfo || {},
   getInfoDataMode: (state) => state.infoDataMode || '',
   getUserInfoQuests: (state) => state.userInfoQuests || '',
   getAllQuests: (state) => state.allQuests || '',

--- a/store/quests/getters.js
+++ b/store/quests/getters.js
@@ -1,4 +1,5 @@
 export default {
+  getChatInfoInviteOnQuest: (state) => state.chatInfoInviteOnQuest,
   getQuestListForInvitation: (state) => state.questListForInvitation || {},
   getWorkersList: (state) => state.workersList,
   getCurrentWorker: (state) => state.currentWorker,

--- a/store/quests/mutations.js
+++ b/store/quests/mutations.js
@@ -1,4 +1,7 @@
 export default {
+  setChatInviteOnQuest(state, data) {
+    state.chatInfoInviteOnQuest = data;
+  },
   setQuestListForInvitation(state, data) {
     state.questListForInvitation = data;
   },

--- a/store/quests/state.js
+++ b/store/quests/state.js
@@ -1,5 +1,6 @@
 export default () => ({
   questListForInvitation: {},
+  chatInfoInviteOnQuest: {},
   currentWorker: {},
   workersList: {},
   allQuests: {},

--- a/store/user/actions.js
+++ b/store/user/actions.js
@@ -1,8 +1,12 @@
 export default {
   async getUserPortfolios({ commit }, id) {
-    const response = await this.$axios.$get(`/v1/user/${id}/portfolio/cases`);
-    commit('setUserPortfolioCases', response.result);
-    return response;
+    try {
+      const response = await this.$axios.$get(`/v1/user/${id}/portfolio/cases`);
+      commit('setUserPortfolioCases', response.result);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
   },
   async setCaseImage({ commit }, { url, formData, type }) {
     const response = await this.$axios.$put(url, formData, {
@@ -15,25 +19,41 @@ export default {
     return response;
   },
   async setCaseData({ commit }, payload) {
-    const response = await this.$axios.$post('/v1/portfolio/add-case', payload);
-    commit('setCaseData', response.result);
-    return response;
+    try {
+      const response = await this.$axios.$post('/v1/portfolio/add-case', payload);
+      commit('setCaseData', response.result);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
   },
   async editCaseData({ commit }, { payload, id }) {
-    const response = await this.$axios.$put(`/v1/portfolio/${id}`, payload);
-    commit('setCaseData', response.result);
-    return response;
+    try {
+      const response = await this.$axios.$put(`/v1/portfolio/${id}`, payload);
+      commit('setCaseData', response.result);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
   },
   async deletePortfolio({ commit }, id) {
-    const response = await this.$axios.$delete(`/v1/portfolio/${id}`);
-    commit('setUserPortfolioCases', response.result);
-    return response;
+    try {
+      const response = await this.$axios.$delete(`/v1/portfolio/${id}`);
+      commit('setUserPortfolioCases', response.result);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
   },
 
   async getAllUserReviews({ commit }, userId) {
-    const response = await this.$axios.$get(`/v1/user/${userId}/reviews`);
-    commit('setUserReviews', response.result);
-    return response;
+    try {
+      const response = await this.$axios.$get(`/v1/user/${userId}/reviews`);
+      commit('setUserReviews', response.result);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
   },
   async sendReviewForUser({ commit }, payload) {
     try {
@@ -66,9 +86,13 @@ export default {
     return response;
   },
   async getUserData({ commit }) {
-    const response = await this.$axios.$get('/v1/profile/me');
-    commit('setUserData', response.result);
-    return response;
+    try {
+      const response = await this.$axios.$get('/v1/profile/me');
+      commit('setUserData', response.result);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
   },
   async setUserRole({ commit }, payload) {
     const response = await this.$axios.$post('/v1/profile/set-role', payload);
@@ -123,12 +147,21 @@ export default {
     return response;
   },
   async disable2FA({ commit }, payload) {
-    const response = await this.$axios.$post('/v1/totp/disable', payload);
-    commit('setDisable2FA', response.result);
-    return response;
+    try {
+      const response = await this.$axios.$post('/v1/totp/disable', payload);
+      commit('setDisable2FA', response.result);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
   },
   async enable2FA(payload) {
-    return await this.$axios.$post('/v1/totp/enable', payload);
+    try {
+      const response = await this.$axios.$post('/v1/totp/enable', payload);
+      return response;
+    } catch (e) {
+      return console.log(e);
+    }
   },
   async confirmEnable2FA({ commit }, payload) {
     const response = await this.$axios.$post('/v1/totp/confirm', payload);

--- a/store/user/actions.js
+++ b/store/user/actions.js
@@ -30,12 +30,19 @@ export default {
     return response;
   },
 
-  async getAllUserReviews({ commit }, id) {
-    const response = await this.$axios.$get(`/v1/user/${id}/reviews`);
+  async getAllUserReviews({ commit }, userId) {
+    const response = await this.$axios.$get(`/v1/user/${userId}/reviews`);
     commit('setUserReviews', response.result);
     return response;
   },
-
+  async sendReviewForUser({ commit }, payload) {
+    try {
+      const response = await this.$axios.$post('/v1/review/send', payload);
+      return response.result;
+    } catch (e) {
+      return console.log(e);
+    }
+  },
   async signIn({ commit, dispatch }, payload) {
     const response = await this.$axios.$post('/v1/auth/login', payload);
     commit('setTokens', response.result);

--- a/utils/enums.js
+++ b/utils/enums.js
@@ -27,3 +27,46 @@ export const StakingTypes = {
   MINING: 'MINING',
   CROSS_CHAIN: 'CROSS_CHAIN',
 };
+
+export const QStatuses = {
+  Rejected: -1,
+  Created: 0,
+  Active: 1,
+  Closed: 2,
+  Dispute: 3,
+  WaitWorker: 4,
+  WaitConfirm: 5,
+  Done: 6,
+};
+
+export const InfoModeE = {
+  RaiseViews: 1,
+  Active: 2,
+  Created: 3,
+  WaitWorker: 4,
+  WaitConfirm: 6,
+  Dispute: 7,
+  Closed: 8,
+  Done: 9,
+};
+export const InfoModeW = {
+  ADChat: 1,
+  Active: 2,
+  Rejected: 3,
+  WaitConfirm: 4,
+  Created: 5,
+  Dispute: 7,
+  Closed: 8,
+  Done: 9,
+};
+export const questPriority = {
+  Low: 1,
+  Normal: 2,
+  Urgent: 3,
+};
+export const questsCompPageMode = {
+  WorkerMy: 1,
+  WorkerOther: 2,
+  EmpMy: 3,
+  EmpOther: 4,
+};

--- a/utils/enums.js
+++ b/utils/enums.js
@@ -28,7 +28,7 @@ export const StakingTypes = {
   CROSS_CHAIN: 'CROSS_CHAIN',
 };
 
-export const QStatuses = {
+export const QuestStatuses = {
   Rejected: -1,
   Created: 0,
   Active: 1,
@@ -39,7 +39,7 @@ export const QStatuses = {
   Done: 6,
 };
 
-export const InfoModeE = {
+export const InfoModeEmployer = {
   RaiseViews: 1,
   Active: 2,
   Created: 3,
@@ -49,7 +49,7 @@ export const InfoModeE = {
   Closed: 8,
   Done: 9,
 };
-export const InfoModeW = {
+export const InfoModeWorker = {
   ADChat: 1,
   Active: 2,
   Rejected: 3,

--- a/utils/enums.js
+++ b/utils/enums.js
@@ -70,3 +70,7 @@ export const questsCompPageMode = {
   EmpMy: 3,
   EmpOther: 4,
 };
+export const responsesType = {
+  Responded: 0,
+  Invited: 1,
+};


### PR DESCRIPTION
- [x] В функции infoStatusText оформить все в объект, где ключ это номер infoDataMode.
- [x] Рефакторинг кода с использованием конструкции  div v-if userRole === 'emloyer' && ![].includes, div v-else-if userRole === 'worker' info component.
- [x] Добавлен divider перед кнопкой Send a request
- [x] У заголовка Quest Materials на странице quests/_id, убран верхний отступ 20px.
- [x] Исправлено у режима Dispute на странице quests/_id положение кнопок и цены. (Не на белом фоне)
- [x] Вынести в enum стадии квеста.
- [x] Исправлена шапка на странице worker/_id
- [x] Добавить кнопку "Go to chat", привязать логику, объект чат, инвайт на квест - сущность чат
- [x] Добавить заполнитель имени на странице /worker/_id, если имя пользователя отсутствует 
- [x] Вывести данные в раздел invited (добавить фильтры и разделение на типы Invited = 1 и Responded = 0)
- [x] На странице worker/_id добавлен запрос на получение данных пользователя
- [ ] Жду добавления сущности чата в  chat responded, для каждого пользователя, для возможности перехода в конкретный чат с пользователем. (При следующем обновлении бэка)
- [ ] Вывести количество откликнувшихся работников на квест на странице /quests при определенных статусах (Жду обновления бэков нужно доп. поле)
- [ ] Добавить метод startChat для начала диалога с пользователем (Жду PR https://github.com/WorkQuest/Website-platform/pull/94 )
- [ ] Убрать использование local storage в модалке review employer.