### PR TITLE
hotfix/16440 hide portfolio tab for employer

### DIFF
--- a/pages/profile/_id/index.vue
+++ b/pages/profile/_id/index.vue
@@ -101,6 +101,20 @@ export default {
       selected: 1,
       questLimits: 100,
       questsObjects: {},
+      pageTabsArray: [
+        {
+          number: 1,
+          title: this.$t('profile.quests'),
+        },
+        {
+          number: 2,
+          title: this.$t('profile.reviews'),
+        },
+        {
+          number: 3,
+          title: this.$t('profile.portfolio'),
+        },
+      ],
     };
   },
   computed: {
@@ -110,32 +124,12 @@ export default {
       userData: 'user/getUserData',
     }),
     pageTabs() {
-      if (this.userRole === 'employer') {
-        return [
-          {
-            number: 1,
-            title: this.$t('profile.quests'),
-          },
-          {
-            number: 2,
-            title: this.$t('profile.reviews'),
-          },
-        ];
-      } if (this.userRole === 'worker') {
-        return [
-          {
-            number: 1,
-            title: this.$t('profile.quests'),
-          },
-          {
-            number: 2,
-            title: this.$t('profile.reviews'),
-          },
-          {
-            number: 3,
-            title: this.$t('profile.portfolio'),
-          },
-        ];
+      const workerArray = this.pageTabsArray;
+      const employerArray = workerArray.slice(0, -1);
+      if (this.userRole === 'worker') {
+        return workerArray;
+      } if (this.userRole === 'employer') {
+        return employerArray;
       }
       return [];
     },

--- a/pages/profile/_id/index.vue
+++ b/pages/profile/_id/index.vue
@@ -62,7 +62,7 @@
           <portfolioTab />
         </div>
         <div
-          v-if="userData.role === 'worker'"
+          v-if="userRole === 'worker'"
           class="button"
         >
           <nuxt-link
@@ -110,20 +110,34 @@ export default {
       userData: 'user/getUserData',
     }),
     pageTabs() {
-      return [
-        {
-          number: 1,
-          title: this.$t('profile.quests'),
-        },
-        {
-          number: 2,
-          title: this.$t('profile.reviews'),
-        },
-        {
-          number: 3,
-          title: this.$t('profile.portfolio'),
-        },
-      ];
+      if (this.userRole === 'employer') {
+        return [
+          {
+            number: 1,
+            title: this.$t('profile.quests'),
+          },
+          {
+            number: 2,
+            title: this.$t('profile.reviews'),
+          },
+        ];
+      } if (this.userRole === 'worker') {
+        return [
+          {
+            number: 1,
+            title: this.$t('profile.quests'),
+          },
+          {
+            number: 2,
+            title: this.$t('profile.reviews'),
+          },
+          {
+            number: 3,
+            title: this.$t('profile.portfolio'),
+          },
+        ];
+      }
+      return [];
     },
     cardLevelClass(idx) {
       const { cards } = this;


### PR DESCRIPTION
(Роль работодателя) My profile > Portfolio > Add case+ > Заполнить все данные > Send - {"ok":false,"code":400002,"data":{"current":"employer","mustHave":"worker"},"msg":"User isn't match role"}

- [x] Исправил, скрыв вкладку portfolio в профиле работодателя, в соответствии с дизайном.