### PR TITLE
fix/18168/wiqi-tab-menu

### DIFF
--- a/pages/wiki/index.vue
+++ b/pages/wiki/index.vue
@@ -31,6 +31,7 @@
               >
                 <a
                   v-for="(item, index) of searched"
+                  v-show="item.id"
                   :key="index"
                   class="searched__item"
                   :href="item.id ? '#' + item.id : ''"
@@ -155,6 +156,7 @@ export default {
   methods: {
     selectTab(item) {
       this.currentTab = item;
+      window.scrollTo(0, 50);
     },
     moveItems(event, payload) {
       const x = event.changedTouches[0].pageX;


### PR DESCRIPTION
hide search refs w/o id, scroll to top on tab selecting